### PR TITLE
Make chain header scrollable

### DIFF
--- a/packages/frontend/src/components/Chain/Chain.css
+++ b/packages/frontend/src/components/Chain/Chain.css
@@ -1,3 +1,8 @@
+.Chain {
+  display: flex;
+  flex-direction: column;
+}
+
 .Chain-header {
   width: 100%;
   height: 108px;
@@ -17,11 +22,7 @@
 }
 
 .Chain-content-container {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  top: 148px;
+  flex: 1;
 }
 
 .Chain-content {

--- a/packages/frontend/src/components/Chains.css
+++ b/packages/frontend/src/components/Chains.css
@@ -2,16 +2,18 @@
   background: #B5AEAE;
   color: #000;
   padding: 0 16px;
-  height: 40px;
   min-width: 1318px;
   position: relative;
+  display: flex;
+  flex-direction: row;
+  overflow-x: scroll;
 }
 
 .Chains-chain {
   padding: 0 12px;
   background: #B5AEAE;
   color: #444;
-  display: inline-block;
+  display: flex;
   border-right: 1px solid rgba(255,255,255,0.5);
   height: 40px;
   line-height: 40px;
@@ -19,6 +21,8 @@
   font-size: 0.8em;
   font-weight: bold;
   position: relative;
+  white-space: nowrap;
+  max-width: 150px;
 }
 
 .Chains-chain:first-child {
@@ -26,12 +30,8 @@
 }
 
 .Chains-fork-me {
-  display: block;
-  padding: 0;
-  margin: 0;
-  position: absolute;
-  right: 12px;
-  top: 6px;
+  align-self: center;
+  padding-right: 16px;
 }
 
 .Chains-fork-me .Icon {
@@ -40,6 +40,13 @@
   height: 28px;
   width: 28px;
   color: #3c3c3b;
+}
+
+.Chains-node-label {
+  margin-right: 0.3em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .Chains-node-count {
@@ -52,7 +59,6 @@
   text-shadow: rgba(0,0,0,0.5) 0 1px 0;
   font-size: 0.9em;
   line-height: 1.4em;
-  margin: 0 -0.3em 0 0.3em;
 }
 
 .Chains-chain-selected {

--- a/packages/frontend/src/components/Chains.tsx
+++ b/packages/frontend/src/components/Chains.tsx
@@ -24,12 +24,12 @@ export class Chains extends React.Component<Chains.Props, {}> {
   public render() {
     return (
       <div className="Chains">
-        {
-          this.chains.map((chain) => this.renderChain(chain))
-        }
         <a className="Chains-fork-me" href="https://github.com/paritytech/substrate-telemetry" target="_blank">
           <Icon src={githubIcon} alt="Fork Me!" />
         </a>
+        {
+          this.chains.map((chain) => this.renderChain(chain))
+        }
       </div>
     );
   }
@@ -43,7 +43,8 @@ export class Chains extends React.Component<Chains.Props, {}> {
 
     return (
       <a key={label} className={className} onClick={this.subscribe.bind(this, label)}>
-        {label} <span className="Chains-node-count" title="Node Count">{nodeCount}</span>
+        <span className="Chains-node-label" title={label}>{label}</span>
+        <span><span className="Chains-node-count" title="Node Count">{nodeCount}</span></span>
       </a>
     )
   }


### PR DESCRIPTION
Hi.

This PR makes the chain header scrollable and will therefore display all chains instead of just a few and fixes #92.

I did the following changes:
- Make the chain header scrollable and therefore display all chains
- Limit the width of each chain header to 150px
   - Display ellipsis if chain label is not completely visible.
   - The full chain label is visible on mouse hover by setting the `title` attribute
- Make the chain header height dynamic to make some room for the horizontal scroll bar if one is needed

I think merging this PR would improve the situation for some time but I also think that the chain header concept has to be reworked completely once the number of chains grows considerably.  

Thanks,
Fabian

![substrate-telemetry-scrollable-header](https://user-images.githubusercontent.com/365690/56404004-cb7b9080-6296-11e9-99d2-bf6343d72157.png)
