### PR TITLE
fix: Failsafe broadcast

### DIFF
--- a/packages/backend/src/Chain.ts
+++ b/packages/backend/src/Chain.ts
@@ -91,6 +91,8 @@ export default class Chain {
   }
 
   public staleNode(node: Node) {
+    node.isStale = true;
+
     this.feeds.broadcast(Feed.staleNode(node));
 
     if (this.height === node.best.number) {

--- a/packages/backend/src/FeedSet.ts
+++ b/packages/backend/src/FeedSet.ts
@@ -50,6 +50,13 @@ export default class FeedSet {
   private sendMessages = () => {
     const data = FeedMessage.serialize(this.messages);
     this.messages = [];
-    this.each(feed => feed.sendData(data));
+
+    this.each(feed => {
+      try {
+        feed.sendData(data);
+      } catch (err) {
+        console.error("Failed to broadcast to feed", err);
+      }
+    });
   }
 }

--- a/packages/backend/src/Node.ts
+++ b/packages/backend/src/Node.ts
@@ -193,7 +193,6 @@ export default class Node {
       this.disconnect();
     } else {
       if (!this.isStale && this.blockTimestamp + NO_BLOCK_TIMEOUT < now) {
-        this.isStale = true;
         this.events.emit('stale');
       }
 


### PR DESCRIPTION
Should fix some issues when a `disconnect` or a `stale` event is halted due to a failure on broadcasting.