### PR TITLE
Dockerfile: add dependency on nodejs 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
-FROM node:alpine
+FROM node:10-alpine
 
 WORKDIR /app
 
-RUN apk update && apk add python g++ make openssh git bash pdftk
-RUN export PYTHONPATH=${PYTHONPATH}:/usr/lib/python2.7
+RUN apk add --no-cache python make g++
 
-COPY ./package.json yarn.lock ./
+COPY ./scripts ./scripts
+COPY ./backend ./backend
+COPY ./packages ./packages
+COPY ./package.json ./yarn.lock ./tsconfig.json ./
 
 RUN yarn 
 
-COPY . .
 
 # Frontend is exposing 3000
 # Backend is exposing 8080


### PR DESCRIPTION
docker build will fail like this:
```
% docker build --tag parity/substrate-telemetry:latest .
Sending build context to Docker daemon  4.423MB
Step 1/7 : FROM node:alpine
 ---> d97a436daee9
Step 2/7 : WORKDIR /app
 ---> Using cache
 ---> 7c3dda0c34df
Step 3/7 : RUN apk update && apk add python g++ make openssh git bash pdftk
 ---> Running in 878af67ffb1f
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/community/x86_64/APKINDEX.tar.gz
v3.9.4-110-gf23de6bf75 [http://dl-cdn.alpinelinux.org/alpine/v3.9/main]
v3.9.4-108-gfec49fe212 [http://dl-cdn.alpinelinux.org/alpine/v3.9/community]
OK: 9774 distinct packages available
  pdftk (missing):
ERROR: unsatisfiable constraints:
    required by: world[pdftk]
The command '/bin/sh -c apk update && apk add python g++ make openssh git bash pdftk' returned a non-zero code: 1
```