### PR TITLE
Process GRANDPA authority id

### DIFF
--- a/packages/backend/src/Node.ts
+++ b/packages/backend/src/Node.ts
@@ -37,12 +37,12 @@ export default class Node {
   public readonly chain: Types.ChainLabel;
   public readonly implementation: Types.NodeImplementation;
   public readonly version: Types.NodeVersion;
-  public readonly address: Maybe<Types.Address>;
   public readonly networkId: Maybe<Types.NetworkId>;
   public readonly authority: boolean;
 
   public readonly events = new EventEmitter() as EventEmitter & NodeEvents;
 
+  public address: Maybe<Types.Address> = null;
   public networkState: Maybe<Types.NetworkState> = null;
   public location: Maybe<Location> = null;
   public lastMessage: Types.Timestamp;
@@ -81,7 +81,6 @@ export default class Node {
     config: string,
     implentation: Types.NodeImplementation,
     version: Types.NodeVersion,
-    address: Maybe<Types.Address>,
     networkId: Maybe<Types.NetworkId>,
     authority: boolean,
     messages: Array<Message>,
@@ -93,7 +92,6 @@ export default class Node {
     this.config = config;
     this.implementation = implentation;
     this.version = version;
-    this.address = address;
     this.authority = authority;
     this.networkId = networkId;
     this.lastMessage = timestamp();
@@ -336,6 +334,7 @@ export default class Node {
 
   private onAfgAuthoritySet(message: AfgAuthoritySet) {
     const {
+      authority_id: authorityId,
       authority_set_id: authoritySetId,
       hash,
       number,
@@ -344,6 +343,8 @@ export default class Node {
     // we manually parse the authorities message, because the array was formatted as a
     // string by substrate before sending it.
     const authorities = JSON.parse(String(message.authorities)) as Types.Authorities;
+
+    this.address = authorityId;
 
     if (JSON.stringify(this.authorities) !== String(message.authorities) ||
         this.authoritySetId !== authoritySetId) {

--- a/packages/backend/src/Node.ts
+++ b/packages/backend/src/Node.ts
@@ -141,9 +141,9 @@ export default class Node {
         if (message.msg === "system.connected") {
           cleanup();
 
-          const { name, chain, config, implementation, version, pubkey, authority, network_id: networkId } = message;
+          const { name, chain, config, implementation, version, authority, network_id: networkId } = message;
 
-          resolve(new Node(ip, socket, name, chain, config, implementation, version, pubkey, networkId, authority === true, messages));
+          resolve(new Node(ip, socket, name, chain, config, implementation, version, networkId, authority === true, messages));
         } else {
           if (messages.length === 10) {
             messages.shift();

--- a/packages/backend/src/message.ts
+++ b/packages/backend/src/message.ts
@@ -68,6 +68,7 @@ export interface AfgReceivedCommit extends AfgReceived {
 export interface AfgAuthoritySet {
   msg: 'afg.authority_set';
   ts: Date;
+  authority_id: Types.Address,
   authorities: Types.Authorities;
   authority_set_id: Types.AuthoritySetId;
   number: Types.BlockNumber;

--- a/packages/backend/src/message.ts
+++ b/packages/backend/src/message.ts
@@ -81,7 +81,6 @@ export interface SystemConnected {
   config: string;
   implementation: Types.NodeImplementation;
   version: Types.NodeVersion;
-  pubkey: Maybe<Types.Address>;
   authority: Maybe<boolean>;
   network_id: Maybe<Types.NetworkId>;
 }

--- a/packages/frontend/src/Connection.ts
+++ b/packages/frontend/src/Connection.ts
@@ -280,7 +280,7 @@ export class Connection {
         case Actions.AfgFinalized: {
           const [nodeAddress, finalizedNumber, finalizedHash] = message.payload;
           const no = parseInt(String(finalizedNumber), 10) as Types.BlockNumber;
-          afg.receivedFinalized( nodeAddress, no, finalizedHash);
+          afg.receivedFinalized(nodeAddress, no, finalizedHash);
 
           break;
         }


### PR DESCRIPTION
The authority id was previously sent to telemetry (as `pubkey`), but removed as part of the [key management refactoring](https://github.com/paritytech/substrate/commit/ed61b1fd98010b85d508bdd17867bf6bfb5cfee7#diff-16b4c34d50bdfcbf732c09c7be1fdcf9L468). It is needed for the consensus visualization.

The corresponding substrate PR is https://github.com/paritytech/substrate/pull/3646.
