### PR TITLE
feat: Add support for system.network_state

### DIFF
--- a/packages/backend/src/Node.ts
+++ b/packages/backend/src/Node.ts
@@ -9,6 +9,7 @@ import {
   Message,
   BestBlock,
   SystemInterval,
+  SystemNetworkState,
   AfgFinalized,
   AfgReceivedPrecommit,
   AfgReceivedPrevote,
@@ -249,6 +250,10 @@ export default class Node {
       this.onSystemInterval(message);
     }
 
+    if (message.msg === 'system.network_state') {
+      this.onSystemNetworkState(message);
+    }
+
     if (message.msg === 'afg.finalized') {
       this.onAfgFinalized(message);
     }
@@ -306,6 +311,10 @@ export default class Node {
         this.events.emit('hardware');
       }
     }
+  }
+
+  private onSystemNetworkState(message: SystemNetworkState) {
+    this.networkState = message.state;
   }
 
   public isAuthority(): boolean {

--- a/packages/backend/src/message.ts
+++ b/packages/backend/src/message.ts
@@ -100,6 +100,11 @@ export interface SystemInterval extends BestBlock {
   finalized_hash: Maybe<Types.BlockHash>;
 }
 
+export interface SystemNetworkState extends MessageBase {
+  msg: 'system.network_state';
+  state: Types.NetworkState;
+}
+
 export interface NodeStart extends BestBlock {
   msg: 'node.start';
 }
@@ -112,6 +117,7 @@ export interface BlockImport extends BestBlock {
 export type Message = MessageBase & (
   | SystemConnected
   | SystemInterval
+  | SystemNetworkState
   | NodeStart
   | BlockImport
   | AfgFinalized


### PR DESCRIPTION
Add support for `system.network_state` messages being split from `system.interval` ([Relevant Substrate PR](https://github.com/paritytech/substrate/pull/3887)).