### PR TITLE
feat: Use array for node map

### DIFF
--- a/packages/common/src/SortedCollection.ts
+++ b/packages/common/src/SortedCollection.ts
@@ -105,8 +105,9 @@ export class SortedCollection<Item extends { id: number }> {
   }
 
   public add(item: Item) {
-    if (this.map.length >= item.id) {
-      this.map = this.map.concat(Array<Maybe<Item>>(10))
+    if (this.map.length <= item.id) {
+      // Grow map if item.id would be out of scope
+      this.map = this.map.concat(Array<Maybe<Item>>(Math.max(10, 1 + item.id - this.map.length)));
     }
 
     this.map[item.id] = item;

--- a/packages/common/src/SortedCollection.ts
+++ b/packages/common/src/SortedCollection.ts
@@ -89,10 +89,10 @@ export namespace SortedCollection {
   export type StateRef = Opaque<number, 'SortedCollection.StateRef'>;
 }
 
-export class SortedCollection<Id, Item extends { id: Id }> {
-  private readonly map = new Map<Id, Item>();
+export class SortedCollection<Item extends { id: number }> {
   private readonly compare: Compare<Item>;
 
+  private map = Array<Maybe<Item>>();
   private list = Array<Item>();
   private changeRef = 0;
 
@@ -105,14 +105,19 @@ export class SortedCollection<Id, Item extends { id: Id }> {
   }
 
   public add(item: Item) {
-    this.map.set(item.id, item);
+    if (this.map.length >= item.id) {
+      this.map = this.map.concat(Array<Maybe<Item>>(10))
+    }
+
+    this.map[item.id] = item;
+
     sortedInsert(item, this.list, this.compare);
 
     this.changeRef += 1;
   }
 
-  public remove(id: Id) {
-    const item = this.map.get(id);
+  public remove(id: number) {
+    const item = this.map[id];
 
     if (!item) {
       return;
@@ -120,21 +125,21 @@ export class SortedCollection<Id, Item extends { id: Id }> {
 
     const index = sortedIndexOf(item, this.list, this.compare);
     this.list.splice(index, 1);
-    this.map.delete(id);
+    this.map[id] = null;
 
     this.changeRef += 1;
   }
 
-  public get(id: Id): Maybe<Item> {
-    return this.map.get(id);
+  public get(id: number): Maybe<Item> {
+    return this.map[id];
   }
 
   public sorted(): Array<Item> {
     return this.list;
   }
 
-  public mut(id: Id, mutator: (item: Item) => void) {
-    const item = this.map.get(id);
+  public mut(id: number, mutator: (item: Item) => void) {
+    const item = this.map[id];
 
     if (!item) {
       return;
@@ -143,8 +148,8 @@ export class SortedCollection<Id, Item extends { id: Id }> {
     mutator(item);
   }
 
-  public mutAndSort(id: Id, mutator: (item: Item) => void) {
-    const item = this.map.get(id);
+  public mutAndSort(id: number, mutator: (item: Item) => void) {
+    const item = this.map[id];
 
     if (!item) {
       return;
@@ -173,7 +178,7 @@ export class SortedCollection<Id, Item extends { id: Id }> {
   }
 
   public clear() {
-    this.map.clear();
+    this.map = [];
     this.list = [];
 
     this.changeRef += 1;

--- a/packages/frontend/src/state.ts
+++ b/packages/frontend/src/state.ts
@@ -220,7 +220,7 @@ export interface State {
   timeDiff: Types.Milliseconds;
   subscribed: Maybe<Types.ChainLabel>;
   chains: Map<Types.ChainLabel, ChainData>;
-  nodes: SortedCollection<Types.NodeId, Node>;
+  nodes: SortedCollection<Node>;
   settings: Readonly<State.Settings>;
   pins: Readonly<Set<Types.NodeName>>;
 }


### PR DESCRIPTION
Since switching to the Rust, `NodeId`s are now indices to a `DenseMap` which re-uses freed indices, making array mapping preferable to a (Hash)`Map`.