### PR TITLE
Fixed warnings by handlings absent voter fields in afg messages

### DIFF
--- a/backend/src/feed.rs
+++ b/backend/src/feed.rs
@@ -144,10 +144,10 @@ pub struct Pong<'a>(pub &'a str);
 pub struct AfgFinalized(pub Address, pub BlockNumber, pub BlockHash);
 
 #[derive(Serialize)]
-pub struct AfgReceivedPrevote(pub Address, pub BlockNumber, pub BlockHash, pub Address);
+pub struct AfgReceivedPrevote(pub Address, pub BlockNumber, pub BlockHash, pub Option<Address>);
 
 #[derive(Serialize)]
-pub struct AfgReceivedPrecommit(pub Address, pub BlockNumber, pub BlockHash, pub Address);
+pub struct AfgReceivedPrecommit(pub Address, pub BlockNumber, pub BlockHash, pub Option<Address>);
 
 #[derive(Serialize)]
 pub struct AfgAuthoritySet(pub Address, pub Address, pub Address, pub BlockNumber, pub BlockHash);

--- a/backend/src/node/message.rs
+++ b/backend/src/node/message.rs
@@ -100,7 +100,7 @@ pub struct AfgFinalized {
 pub struct AfgReceived {
     pub target_hash: BlockHash,
     pub target_number: Box<str>,
-    pub voter: Box<str>,
+    pub voter: Option<Box<str>>,
 }
 
 #[derive(Deserialize, Debug, Clone)]


### PR DESCRIPTION
Makes the voter field an Option for afg.received_commit, afg.received_precommit and afg.received_prevote messages, allowing it to be absent.

Closes #213