### PR TITLE
Quick subscribe

### DIFF
--- a/backend/src/chain.rs
+++ b/backend/src/chain.rs
@@ -392,6 +392,11 @@ impl Handler<Subscribe> for Chain {
         ));
         self.serializer.push(feed::BestFinalized(self.finalized.height, self.finalized.hash));
 
+        // Send subscribtion confirmation and chain head before doing all the nodes
+        if let Some(serialized) = self.serializer.finalize() {
+            feed.do_send(serialized);
+        }
+
         for (nid, node) in self.nodes.iter() {
             self.serializer.push(feed::AddedNode(nid, node));
             self.serializer.push(feed::FinalizedBlock(nid, node.finalized().height, node.finalized().hash));

--- a/backend/src/chain.rs
+++ b/backend/src/chain.rs
@@ -392,12 +392,15 @@ impl Handler<Subscribe> for Chain {
         ));
         self.serializer.push(feed::BestFinalized(self.finalized.height, self.finalized.hash));
 
-        // Send subscribtion confirmation and chain head before doing all the nodes
-        if let Some(serialized) = self.serializer.finalize() {
-            feed.do_send(serialized);
-        }
+        for (idx, (nid, node)) in self.nodes.iter().enumerate() {
+            // Send subscribtion confirmation and chain head before doing all the nodes,
+            // and continue sending batches of 32 nodes a time over the wire subsequently
+            if idx % 32 == 0 {
+                if let Some(serialized) = self.serializer.finalize() {
+                    feed.do_send(serialized);
+                }
+            }
 
-        for (nid, node) in self.nodes.iter() {
             self.serializer.push(feed::AddedNode(nid, node));
             self.serializer.push(feed::FinalizedBlock(nid, node.finalized().height, node.finalized().hash));
             if node.stale() {


### PR DESCRIPTION
+ Send chain head before the node list
+ Partition node list into batches of 32 that are sent as separate WS messages

This ought to make everything more responsive when first opening telemetry