### PR TITLE
Reduce the size of the docker images

### DIFF
--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -1,11 +1,14 @@
-FROM rust
+FROM rust as builder
 
-WORKDIR /app
-
+WORKDIR /build
 COPY ./backend .
-
 RUN cargo build --release
+
+#####################################
+FROM phusion/baseimage:0.11
+
+COPY --from=builder /build/target/release/telemetry /usr/local/bin
 
 EXPOSE 8000
 
-ENTRYPOINT [ "./target/release/telemetry" ]
+ENTRYPOINT [ "telemetry" ]

--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -8,4 +8,4 @@ COPY ./scripts ./scripts
 COPY ./packages ./packages
 COPY ./package.json ./yarn.lock ./tsconfig.json ./
 
-RUN yarn 
+RUN yarn && yarn cache clean


### PR DESCRIPTION
This PR shrinks (a lot) the size of the docker images that are produced:
- around 200MB less on the frontend
- more than 1GB less for the backend