### PR TITLE
Listen by default to the local interface and allows changing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ cd backend
 cargo build --release
 ./target/release/telemetry
 ```
+
+By default, telemetry will listen on the local interface only (127.0.0.1) on port 8000. You may change both those values:
+
+Use another port:
+```
+PORT=8123 telemetry
+```
+
+You may also change the the listening interface. This is especially required if you are using docker:
+```
+BIND=0.0.0.0 telemetry
+```
+
 ### Terminal 2 - Frontend
 ```
 yarn start:frontend

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -90,6 +90,8 @@ fn health(
         })
 }
 
+/// Telemetry entry point. Listening by default on 127.0.0.1:8000.
+/// This can be changed using the `PORT` and `BIND` ENV variables.
 fn main() -> std::io::Result<()> {
     use web::{resource, get};
 
@@ -101,6 +103,7 @@ fn main() -> std::io::Result<()> {
     let locator = SyncArbiter::start(4, move || factory.create());
 
     let port = std::env::var("PORT").ok().and_then(|v| v.parse().ok()).unwrap_or(8000u16);
+    let bind_address = std::env::var("BIND").ok().unwrap_or("127.0.0.1".to_string());
 
     HttpServer::new(move || {
         App::new()
@@ -115,7 +118,7 @@ fn main() -> std::io::Result<()> {
             .service(resource("/health").route(get().to_async(health)))
             .service(resource("/health/").route(get().to_async(health)))
     })
-    .bind(format!("0.0.0.0:{}", port))?
+    .bind(format!("{}:{}", bind_address, port))?
     .start();
 
     sys.run()


### PR DESCRIPTION
This PR introduces the following:
- listens to `127.0.0.1:8000` by default instead of the former more open `0.0.0.0:8000`
- allows changing the interface we listen to: `BIND=0.0.0.0` brings back the previous behavior
- document the supported ENV in the code and in the readme