### PR TITLE
add new implementation names

### DIFF
--- a/frontend/src/components/List/Column.tsx
+++ b/frontend/src/components/List/Column.tsx
@@ -64,9 +64,11 @@ import unknownImplementationIcon from '../../icons/question-solid.svg';
 
 const ICONS = {
   'parity-polkadot': parityPolkadotIcon,
+  'Parity Polkadot': parityPolkadotIcon,
   'polkadot-js': polkadotJsIcon,
   'airalab-robonomics': airalabRobonomicsIcon,
   'substrate-node': paritySubstrateIcon,
+  'Substrate Node': paritySubstrateIcon,
   'edgeware-node': edgewareIcon,
   'Edgeware Node': edgewareIcon,
   'joystream-node': joystreamIcon,


### PR DESCRIPTION
These were recently renamed in https://github.com/paritytech/substrate/pull/5271 https://github.com/paritytech/polkadot/pull/935.