### PR TITLE
Further decouple SystemInterval values.

### DIFF
--- a/backend/src/node.rs
+++ b/backend/src/node.rs
@@ -142,12 +142,22 @@ impl Node {
     }
 
     pub fn update_stats(&mut self, interval: &SystemInterval) -> Option<&NodeStats> {
-        if self.stats != interval.stats {
-            self.stats = interval.stats;
-            Some(&self.stats)
-        } else {
-            None
-        }
+      let mut changed = false;
+
+      if let Some(peers) = interval.peers {
+          self.stats.peers = peers;
+          changed = true;
+      }
+      if let Some(txcount) = interval.txcount {
+          self.stats.txcount = txcount;
+          changed = true;
+      }
+
+      if changed {
+          Some(&self.stats)
+      } else {
+          None
+      }
     }
 
     pub fn update_io(&mut self, interval: &SystemInterval) -> Option<&NodeIO> {

--- a/backend/src/node.rs
+++ b/backend/src/node.rs
@@ -145,12 +145,16 @@ impl Node {
       let mut changed = false;
 
       if let Some(peers) = interval.peers {
-          self.stats.peers = peers;
-          changed = true;
+          if peers != self.stats.peers {
+              self.stats.peers = peers;
+              changed = true;
+          }
       }
       if let Some(txcount) = interval.txcount {
-          self.stats.txcount = txcount;
-          changed = true;
+          if txcoint != self.stats.txcount {
+              self.stats.txcount = txcount;
+              changed = true;
+          }
       }
 
       if changed {

--- a/backend/src/node.rs
+++ b/backend/src/node.rs
@@ -151,7 +151,7 @@ impl Node {
           }
       }
       if let Some(txcount) = interval.txcount {
-          if txcoint != self.stats.txcount {
+          if txcount != self.stats.txcount {
               self.stats.txcount = txcount;
               changed = true;
           }

--- a/backend/src/node/message.rs
+++ b/backend/src/node/message.rs
@@ -2,7 +2,7 @@ use actix::prelude::*;
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use serde::de::IgnoredAny;
-use crate::node::{NodeDetails, NodeStats};
+use crate::node::NodeDetails;
 use crate::types::{Block, BlockNumber, BlockHash};
 
 #[derive(Deserialize, Debug, Message)]
@@ -63,14 +63,14 @@ pub struct SystemConnected {
 
 #[derive(Deserialize, Debug)]
 pub struct SystemInterval {
-    #[serde(flatten)]
-    pub stats: NodeStats,
+    pub peers: Option<u64>,
+    pub txcount: Option<u64>,
     pub bandwidth_upload: Option<f64>,
     pub bandwidth_download: Option<f64>,
     pub finalized_height: Option<BlockNumber>,
     pub finalized_hash: Option<BlockHash>,
     #[serde(flatten)]
-    pub block: Block,
+    pub block: Option<Block>,
     pub network_state: Option<IgnoredAny>,
     pub used_state_cache_size: Option<f32>,
 }
@@ -132,9 +132,8 @@ impl Block {
 impl Details {
     pub fn best_block(&self) -> Option<&Block> {
         match self {
-            Details::BlockImport(block) | Details::SystemInterval(SystemInterval { block, .. }) => {
-                Some(block)
-            }
+            Details::BlockImport(block) => Some(block),
+            Details::SystemInterval(SystemInterval { block, .. }) => block.as_ref(),
             _ => None,
         }
     }


### PR DESCRIPTION
In principle, most values in a `SystemInterval` can already be reported independently to the backend, which is a good thing. Unfortunately there are still two constraints:

  1. `txcount` and `peers` must be sent together.
  2. `block` information must always be sent with any other information, i.e. it is not possible to send any update that does not include block information.

This unnecessarily restricts the granularity at which values can be sent to the telemetry backend. For example, the `txcount` and `peers` actually come from quite different sources in substrate, where either one may be unavailable independently of the other. This either prevents reporting one of these values when the other is not available or requires the code that sends these values to remember the last values of any such fields that are coupled together in this manner, just so an update can be sent.

I think the frontend, i.e. the Telemetry, is the best place to handle this by giving maximum flexibility to the incoming data, meaning as much as possible it does not prescribe which values must be sent together and just updates its local state whenever it gets a new value. Therefore this PR decouples `txcount` and `peers` in the `SystemInterval` message and makes the `block` field optional.

Context: https://github.com/paritytech/substrate/pull/6986/files#r487127101.