### PR TITLE
Fix a panic in actix-web normalize middleware

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -939,7 +939,6 @@ checksum = "95314d38584ffbfda215621d723e0a3906f032e03ae5551e650058dac83d4797"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -970,17 +969,6 @@ checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 dependencies = [
  "futures 0.1.30",
  "num_cpus",
-]
-
-[[package]]
-name = "futures-executor"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f8e0c9258abaea85e78ebdda17ef9666d390e987f006be6080dfe354b708cb"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
 ]
 
 [[package]]
@@ -2395,7 +2383,6 @@ dependencies = [
  "chrono",
  "clap",
  "fnv",
- "futures 0.3.7",
  "log",
  "num-traits",
  "parking_lot 0.11.0",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -239,8 +239,7 @@ dependencies = [
 [[package]]
 name = "actix-web"
 version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b12fe25e11cd9ed2ef2e428427eb6178a1b363f3f7f0dab8278572f11b2da1"
+source = "git+https://github.com/maciejhirsz/actix-web?branch=no-panic-normalize#89791b4df12295bf0145d0402a059d1315cd90ff"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -940,6 +939,7 @@ checksum = "95314d38584ffbfda215621d723e0a3906f032e03ae5551e650058dac83d4797"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -970,6 +970,17 @@ checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 dependencies = [
  "futures 0.1.30",
  "num_cpus",
+]
+
+[[package]]
+name = "futures-executor"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5f8e0c9258abaea85e78ebdda17ef9666d390e987f006be6080dfe354b708cb"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -2384,6 +2395,7 @@ dependencies = [
  "chrono",
  "clap",
  "fnv",
+ "futures 0.3.7",
  "log",
  "num-traits",
  "parking_lot 0.11.0",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -13,6 +13,7 @@ actix-http = "2.0.0"
 bytes = "0.5.6"
 chrono = { version = "0.4", features = ["serde"] }
 fnv = "1.0.7"
+futures = "0.3.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 primitive-types = { version = "0.7.2", features = ["serde"] }
@@ -27,3 +28,6 @@ clap = "3.0.0-beta.2"
 [profile.release]
 lto = true
 panic = "abort"
+
+[patch.crates-io]
+actix-web = { git = "https://github.com/maciejhirsz/actix-web", branch = "no-panic-normalize" }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -13,7 +13,6 @@ actix-http = "2.0.0"
 bytes = "0.5.6"
 chrono = { version = "0.4", features = ["serde"] }
 fnv = "1.0.7"
-futures = "0.3.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 primitive-types = { version = "0.7.2", features = ["serde"] }


### PR DESCRIPTION
Actual fix: https://github.com/maciejhirsz/actix-web/commit/89791b4df12295bf0145d0402a059d1315cd90ff

Will revert back to stock `actix-web` once the fix is merged upstream.

[Upstream PR](https://github.com/actix/actix-web/pull/1762) for tracking.