### PR TITLE
Prevent nodes out of viewport triggering render

### DIFF
--- a/frontend/src/Connection.ts
+++ b/frontend/src/Connection.ts
@@ -149,7 +149,7 @@ export class Connection {
 
   public handleMessages = (messages: FeedMessage.Message[]) => {
     const { nodes, chains, sortBy, selectedColumns } = this.state;
-    const ref = nodes.ref();
+    const { ref } = nodes;
 
     const updateState: UpdateBound = (state) => {
       this.state = this.update(state);

--- a/frontend/src/common/SortedCollection.ts
+++ b/frontend/src/common/SortedCollection.ts
@@ -123,7 +123,7 @@ export class SortedCollection<Item extends { id: number }> {
     this.compare = compare;
   }
 
-  // Set a new focus within which order changes bump `changeRef`
+  // Set a new `Focus`. Any changes to the order of items within the `Focus` will trigger an increase to `changeRef`, which in turn triggers a re-render.
   public setFocus(start: number, end: number) {
     this.focus = { start, end };
   }

--- a/frontend/src/common/SortedCollection.ts
+++ b/frontend/src/common/SortedCollection.ts
@@ -246,7 +246,7 @@ export class SortedCollection<Item extends { id: number }> {
   }
 
   // Get the reference to current ordering state of focused items.
-  public ref(): SortedCollection.StateRef {
+  public get ref(): SortedCollection.StateRef {
     return this.changeRef as SortedCollection.StateRef;
   }
 

--- a/frontend/src/common/SortedCollection.ts
+++ b/frontend/src/common/SortedCollection.ts
@@ -97,14 +97,35 @@ export namespace SortedCollection {
   export type StateRef = Opaque<number, 'SortedCollection.StateRef'>;
 }
 
+interface Focus {
+  start: number;
+  end: number;
+}
+
 export class SortedCollection<Item extends { id: number }> {
+  // Comparator function used to sort the collection
   private compare: Compare<Item>;
+  // Mapping item `id` to the `Item`, this uses array as a structure with
+  // the assumption that `id`s provided are increments from `0`, and that
+  // vacant `id`s will be re-used in the future.
   private map = Array<Maybe<Item>>();
+  // Actual sorted list of `Item`s.
   private list = Array<Item>();
+  // Internal tracker for changes, this number increments whenever the
+  // order of the **focused** elements in the collection changes
   private changeRef = 0;
+  // Marks the range of indicies that are focused for tracking.
+  // **Note:** `start` is inclusive, while `end` is exclusive (much like
+  // `Array.slice()`).
+  private focus: Focus = { start: 0, end: 0 };
 
   constructor(compare: Compare<Item>) {
     this.compare = compare;
+  }
+
+  // Set a new focus within which order changes bump `changeRef`
+  public setFocus(start: number, end: number) {
+    this.focus = { start, end };
   }
 
   public setComparator(compare: Compare<Item>) {
@@ -112,10 +133,6 @@ export class SortedCollection<Item extends { id: number }> {
     this.list = this.map.filter((item) => item != null) as Item[];
     this.list.sort(compare);
     this.changeRef += 1;
-  }
-
-  public ref(): SortedCollection.StateRef {
-    return this.changeRef as SortedCollection.StateRef;
   }
 
   public add(item: Item) {
@@ -131,9 +148,11 @@ export class SortedCollection<Item extends { id: number }> {
 
     this.map[item.id] = item;
 
-    sortedInsert(item, this.list, this.compare);
+    const index = sortedInsert(item, this.list, this.compare);
 
-    this.changeRef += 1;
+    if (index < this.focus.end) {
+      this.changeRef += 1;
+    }
   }
 
   public remove(id: number) {
@@ -147,7 +166,9 @@ export class SortedCollection<Item extends { id: number }> {
     this.list.splice(index, 1);
     this.map[id] = null;
 
-    this.changeRef += 1;
+    if (index < this.focus.end) {
+      this.changeRef += 1;
+    }
   }
 
   public get(id: number): Maybe<Item> {
@@ -184,7 +205,13 @@ export class SortedCollection<Item extends { id: number }> {
     const newIndex = sortedInsert(item, this.list, this.compare);
 
     if (newIndex !== index) {
-      this.changeRef += 1;
+      const outOfFocus =
+        (index < this.focus.start && newIndex < this.focus.start) ||
+        (index >= this.focus.end && newIndex >= this.focus.end);
+
+      if (!outOfFocus) {
+        this.changeRef += 1;
+      }
     }
   }
 
@@ -207,6 +234,7 @@ export class SortedCollection<Item extends { id: number }> {
   public mutEachAndSort(mutator: (item: Item) => void) {
     this.list.forEach(mutator);
     this.list.sort(this.compare);
+    this.changeRef += 1;
   }
 
   public clear() {
@@ -216,6 +244,12 @@ export class SortedCollection<Item extends { id: number }> {
     this.changeRef += 1;
   }
 
+  // Get the reference to current ordering state of focused items.
+  public ref(): SortedCollection.StateRef {
+    return this.changeRef as SortedCollection.StateRef;
+  }
+
+  // Check if order of focused items has changed since obtaining a `ref`.
   public hasChangedSince(ref: SortedCollection.StateRef): boolean {
     return this.changeRef > ref;
   }

--- a/frontend/src/common/SortedCollection.ts
+++ b/frontend/src/common/SortedCollection.ts
@@ -123,11 +123,6 @@ export class SortedCollection<Item extends { id: number }> {
     this.compare = compare;
   }
 
-  // Set a new `Focus`. Any changes to the order of items within the `Focus` will trigger an increase to `changeRef`, which in turn triggers a re-render.
-  public setFocus(start: number, end: number) {
-    this.focus = { start, end };
-  }
-
   public setComparator(compare: Compare<Item>) {
     this.compare = compare;
     this.list = this.map.filter((item) => item != null) as Item[];
@@ -242,6 +237,12 @@ export class SortedCollection<Item extends { id: number }> {
     this.list = [];
 
     this.changeRef += 1;
+  }
+
+  // Set a new `Focus`. Any changes to the order of items within the `Focus`
+  // will increment `changeRef`.
+  public setFocus(start: number, end: number) {
+    this.focus = { start, end };
   }
 
   // Get the reference to current ordering state of focused items.

--- a/frontend/src/components/List/List.tsx
+++ b/frontend/src/components/List/List.tsx
@@ -52,11 +52,11 @@ export class List extends React.Component<List.Props, {}> {
   }
 
   public render() {
-    const { selectedColumns } = this.props.appState;
-    const { pins, sortBy } = this.props;
-    const { filter } = this.state;
+    const { pins, sortBy, appState } = this.props;
+    const { selectedColumns } = appState;
+    const { filter, listStart, listEnd } = this.state;
 
-    let nodes = this.props.appState.nodes.sorted();
+    let nodes = appState.nodes.sorted();
 
     if (filter != null) {
       nodes = nodes.filter(filter);
@@ -73,9 +73,12 @@ export class List extends React.Component<List.Props, {}> {
           </React.Fragment>
         );
       }
+      // With filter present, we can no longer guarantee that focus corresponds
+      // to rendering view, so we put the whole list in focus
+      appState.nodes.setFocus(0, nodes.length);
+    } else {
+      appState.nodes.setFocus(listStart, listEnd);
     }
-
-    const { listStart, listEnd } = this.state;
 
     const height = TH_HEIGHT + nodes.length * TR_HEIGHT;
     const transform = `translateY(${listStart * TR_HEIGHT}px)`;


### PR DESCRIPTION
Whenever the backend sends a new block update for a node, the position of that node in the sorted list (using the `SortedCollection` abstraction) needs to be updated. Currently, any alternation of the order prompts the render pipeline in React. The actual table rendered in the UI has already been truncated only to the slice of the list that's visible in the viewport so updates to nodes outside of the viewport produce no changes to the DOM at all, however it would still trigger the VDOM diffing of the entire UI. This was fine while the number of nodes was heavily limited, however we now have multiple chains with multiples of hundreds of nodes on them, the cascade of updates that follows a new block creation can clog the UI, even for seconds.

This PR effectively prevents the React rendering pipeline from being triggered by list ordering changes happening outside of the viewport, there should be no discernable difference in how the UI behaves, aside from being more responsive.

Chromium on my machine is particularly bad, here is a [clip of current live, vs static build of this branch running on live backend](https://maciej.codes/kosz/performance.mp4).