### PR TITLE
More performance tweaks

### DIFF
--- a/frontend/src/components/List/List.css
+++ b/frontend/src/components/List/List.css
@@ -1,4 +1,6 @@
 .List {
+  /* Prevents the list from auto-scrolling while cascading node
+   * updates on new block, which helps with performance. */
   overflow-anchor: none;
 }
 

--- a/frontend/src/components/List/List.css
+++ b/frontend/src/components/List/List.css
@@ -1,3 +1,7 @@
+.List {
+  overflow-anchor: none;
+}
+
 .List-no-nodes {
   font-size: 30px;
   padding-top: 20vh;

--- a/frontend/src/components/List/List.tsx
+++ b/frontend/src/components/List/List.tsx
@@ -37,7 +37,6 @@ export class List extends React.Component<List.Props, {}> {
   };
 
   private relativeTop = -1;
-  private scrolling = false;
 
   public componentDidMount() {
     this.onScroll();
@@ -108,10 +107,6 @@ export class List extends React.Component<List.Props, {}> {
   }
 
   private onScroll = () => {
-    if (this.scrolling) {
-      return;
-    }
-
     const relativeTop = divisibleBy(
       window.scrollY - (HEADER + TR_HEIGHT),
       TR_HEIGHT * ROW_MARGIN
@@ -122,13 +117,7 @@ export class List extends React.Component<List.Props, {}> {
     }
 
     this.relativeTop = relativeTop;
-    this.scrolling = true;
 
-    window.requestAnimationFrame(this.onScrollRAF);
-  };
-
-  private onScrollRAF = () => {
-    const { relativeTop } = this;
     const { viewportHeight } = this.state;
     const top = Math.max(relativeTop, 0);
     const height =
@@ -139,8 +128,6 @@ export class List extends React.Component<List.Props, {}> {
     if (listStart !== this.state.listStart || listEnd !== this.state.listEnd) {
       this.setState({ listStart, listEnd });
     }
-
-    this.scrolling = false;
   };
 
   private onResize = () => {


### PR DESCRIPTION
This is another tweak to performance that nearly eliminates all stutter on all browsers, there are effectively three changes here:

1. State updates (which trigger a render) coming from the backend are now throttled to the UI framerate. Chrome seems to have been able to skip frames entirely on its own, but Firefox insisted on rendering separate frames as they come, regardless of how many updates are queued up. Since BE sends updates in real time, we often get more than one node update during the 16ms (at 60fps) it takes to render a frame, which would then block the rendering pipeline for that many frames. #296 capped that block to only the nodes in the viewport, but it still produced a stutter, especially on Chromium without hardware acceleration.
2. Disabled content anchoring for the whole list view in CSS, which prevents the browser from automatically scrolling down the list while updates are happening (which would then trigger scroll events, following by state updates, following by even more render updates, making 1. even worse).
3. Decoupled scroll event handling from the framerate, which should make scrolling up and down in Firefox more responsive, though given 1. and 2. this is now hardly noticable.