### PR TITLE
Use startup_time from system.connected

### DIFF
--- a/backend/src/aggregator.rs
+++ b/backend/src/aggregator.rs
@@ -290,7 +290,7 @@ impl Handler<Connect> for Aggregator {
 
         connector.do_send(Connected(fid));
 
-        self.serializer.push(feed::Version(30));
+        self.serializer.push(feed::Version(31));
 
         // TODO: keep track on number of nodes connected to each chain
         for (_, entry) in self.chains.iter() {

--- a/backend/src/feed.rs
+++ b/backend/src/feed.rs
@@ -172,7 +172,7 @@ impl Serialize for AddedNode<'_> {
         tup.serialize_element(node.hardware())?;
         tup.serialize_element(node.block_details())?;
         tup.serialize_element(&node.location())?;
-        tup.serialize_element(&node.connected_at())?;
+        tup.serialize_element(&node.startup_time())?;
         tup.end()
     }
 }

--- a/backend/src/node.rs
+++ b/backend/src/node.rs
@@ -33,16 +33,20 @@ pub struct Node {
     location: Option<Arc<NodeLocation>>,
     /// Flag marking if the node is stale (not syncing or producing blocks)
     stale: bool,
-    /// Connected at timestamp
-    connected_at: Timestamp,
+    /// Unix timestamp for when node started up (falls back to connection time)
+    startup_time: Timestamp,
     /// Network state
     network_state: Option<Bytes>,
 }
 
 impl Node {
-    pub fn new(details: NodeDetails) -> Self {
-        Node {
+    pub fn new(mut details: NodeDetails) -> Self {
+        let startup_time = details.startup_time
+            .take()
+            .and_then(|time| time.parse().ok())
+            .unwrap_or_else(|| now());
 
+        Node {
             details,
             stats: NodeStats::default(),
             io: NodeIO::default(),
@@ -52,7 +56,7 @@ impl Node {
             hardware: NodeHardware::default(),
             location: None,
             stale: false,
-            connected_at: now(),
+            startup_time,
             network_state: None,
         }
     }
@@ -230,7 +234,7 @@ impl Node {
         }
     }
 
-    pub fn connected_at(&self) -> Timestamp {
-        self.connected_at
+    pub fn startup_time(&self) -> Timestamp {
+        self.startup_time
     }
 }

--- a/backend/src/node.rs
+++ b/backend/src/node.rs
@@ -34,7 +34,7 @@ pub struct Node {
     /// Flag marking if the node is stale (not syncing or producing blocks)
     stale: bool,
     /// Unix timestamp for when node started up (falls back to connection time)
-    startup_time: Timestamp,
+    startup_time: Option<Timestamp>,
     /// Network state
     network_state: Option<Bytes>,
 }
@@ -43,8 +43,7 @@ impl Node {
     pub fn new(mut details: NodeDetails) -> Self {
         let startup_time = details.startup_time
             .take()
-            .and_then(|time| time.parse().ok())
-            .unwrap_or_else(|| now());
+            .and_then(|time| time.parse().ok());
 
         Node {
             details,
@@ -234,7 +233,7 @@ impl Node {
         }
     }
 
-    pub fn startup_time(&self) -> Timestamp {
+    pub fn startup_time(&self) -> Option<Timestamp> {
         self.startup_time
     }
 }

--- a/backend/src/node/connector.rs
+++ b/backend/src/node/connector.rs
@@ -161,7 +161,6 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for NodeConnector {
 
         match serde_json::from_slice(&data) {
             Ok(msg) => {
-                // log::info!("New node message: {}", std::str::from_utf8(&data).unwrap_or_else(|_| "INVALID UTF8"));
                 self.handle_message(msg, data, ctx)
             },
             #[cfg(debug)]

--- a/backend/src/node/connector.rs
+++ b/backend/src/node/connector.rs
@@ -161,7 +161,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for NodeConnector {
 
         match serde_json::from_slice(&data) {
             Ok(msg) => {
-                // info!("New node message: {}", std::str::from_utf8(&data).unwrap_or_else(|_| "INVALID UTF8"));
+                // log::info!("New node message: {}", std::str::from_utf8(&data).unwrap_or_else(|_| "INVALID UTF8"));
                 self.handle_message(msg, data, ctx)
             },
             #[cfg(debug)]

--- a/backend/src/node/message.rs
+++ b/backend/src/node/message.rs
@@ -8,16 +8,9 @@ use crate::types::{Block, BlockNumber, BlockHash};
 #[derive(Deserialize, Debug, Message)]
 #[rtype(result = "()")]
 pub struct NodeMessage {
-    pub level: Level,
     pub ts: DateTime<Utc>,
     #[serde(flatten)]
     pub details: Details,
-}
-
-#[derive(Deserialize, Debug)]
-pub enum Level {
-    #[serde(rename = "INFO")]
-    Info,
 }
 
 #[derive(Deserialize, Debug)]

--- a/backend/src/types.rs
+++ b/backend/src/types.rs
@@ -17,6 +17,7 @@ pub struct NodeDetails {
     pub version: Box<str>,
     pub validator: Option<Box<str>>,
     pub network_id: Option<Box<str>>,
+    pub startup_time: Option<Box<str>>,
 }
 
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/frontend/src/Connection.ts
+++ b/frontend/src/Connection.ts
@@ -204,7 +204,7 @@ export class Connection {
             nodeHardware,
             blockDetails,
             location,
-            connectedAt,
+            startupTime,
           ] = message.payload;
           const pinned = this.pins.has(nodeDetails[0]);
           const node = new Node(
@@ -216,7 +216,7 @@ export class Connection {
             nodeHardware,
             blockDetails,
             location,
-            connectedAt
+            startupTime
           );
 
           nodes.add(node);

--- a/frontend/src/common/feed.ts
+++ b/frontend/src/common/feed.ts
@@ -80,7 +80,7 @@ export namespace Variants {
       NodeHardware,
       BlockDetails,
       Maybe<NodeLocation>,
-      Timestamp
+      Maybe<Timestamp>
     ];
   }
 

--- a/frontend/src/common/index.ts
+++ b/frontend/src/common/index.ts
@@ -9,4 +9,4 @@ import * as FeedMessage from './feed';
 export { Types, FeedMessage };
 
 // Increment this if breaking changes were made to types in `feed.ts`
-export const VERSION: Types.FeedVersion = 30 as Types.FeedVersion;
+export const VERSION: Types.FeedVersion = 31 as Types.FeedVersion;

--- a/frontend/src/components/List/Column/UptimeColumn.tsx
+++ b/frontend/src/components/List/Column/UptimeColumn.tsx
@@ -9,7 +9,7 @@ export class UptimeColumn extends React.Component<Column.Props, {}> {
   public static readonly icon = icon;
   public static readonly width = 58;
   public static readonly setting = 'uptime';
-  public static readonly sortBy = ({ connectedAt }: Node) => connectedAt || 0;
+  public static readonly sortBy = ({ startupTime }: Node) => startupTime || 0;
 
   public shouldComponentUpdate(nextProps: Column.Props) {
     // Uptime only changes when the node does
@@ -17,11 +17,15 @@ export class UptimeColumn extends React.Component<Column.Props, {}> {
   }
 
   render() {
-    const { connectedAt } = this.props.node;
+    const { startupTime } = this.props.node;
+
+    if (!startupTime) {
+      return <td className="Column">-</td>;
+    }
 
     return (
       <td className="Column">
-        <Ago when={connectedAt} justTime={true} />
+        <Ago when={startupTime} justTime={true} />
       </td>
     );
   }

--- a/frontend/src/state.ts
+++ b/frontend/src/state.ts
@@ -43,7 +43,7 @@ export class Node {
   public readonly version: Types.NodeVersion;
   public readonly validator: Maybe<Types.Address>;
   public readonly networkId: Maybe<Types.NetworkId>;
-  public readonly connectedAt: Types.Timestamp;
+  public readonly startupTime: Maybe<Types.Timestamp>;
 
   public readonly sortableName: string;
   public readonly sortableVersion: number;
@@ -82,7 +82,7 @@ export class Node {
     nodeHardware: Types.NodeHardware,
     blockDetails: Types.BlockDetails,
     location: Maybe<Types.NodeLocation>,
-    connectedAt: Types.Timestamp
+    startupTime: Maybe<Types.Timestamp>
   ) {
     const [name, implementation, version, validator, networkId] = nodeDetails;
 
@@ -94,7 +94,7 @@ export class Node {
     this.version = version;
     this.validator = validator;
     this.networkId = networkId;
-    this.connectedAt = connectedAt;
+    this.startupTime = startupTime;
 
     const [major = 0, minor = 0, patch = 0] = (version || '0.0.0')
       .split('.')


### PR DESCRIPTION
Bonus: removed `level` from messages, so they can be dropped in substrate.