### PR TITLE
Wrap message's content into node's message

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,12 @@
 root = true
-
 [*]
 charset = utf-8
-indent_style = space
-indent_size = 2
 trim_trailing_whitespace = true
 insert_final_newline = true
+indent_style = space
+
+[frontend/**]
+indent_size = 2
+
+[backend/**]
+indent_size = 4

--- a/backend/src/chain.rs
+++ b/backend/src/chain.rs
@@ -319,12 +319,12 @@ impl Handler<UpdateNode> for Chain {
     fn handle(&mut self, msg: UpdateNode, _: &mut Self::Context) {
         let UpdateNode { nid, msg, raw } = msg;
 
-        if let Some(block) = msg.details.best_block() {
+        if let Some(block) = msg.payload.details.best_block() {
             self.handle_block(block, nid);
         }
 
         if let Some(node) = self.nodes.get_mut(nid) {
-            match msg.details {
+            match msg.payload.details {
                 Details::SystemInterval(ref interval) => {
                     if interval.network_state.is_some() {
                         if let Some(raw) = raw {
@@ -391,7 +391,7 @@ impl Handler<UpdateNode> for Chain {
                 _ => (),
             }
 
-            if let Some(block) = msg.details.finalized_block() {
+            if let Some(block) = msg.payload.details.finalized_block() {
                 if let Some(finalized) = node.update_finalized(block) {
                     self.serializer.push(feed::FinalizedBlock(nid, finalized.height, finalized.hash));
 

--- a/backend/src/chain.rs
+++ b/backend/src/chain.rs
@@ -319,12 +319,12 @@ impl Handler<UpdateNode> for Chain {
     fn handle(&mut self, msg: UpdateNode, _: &mut Self::Context) {
         let UpdateNode { nid, msg, raw } = msg;
 
-        if let Some(block) = msg.payload.details.best_block() {
+        if let Some(block) = msg.payload().details.best_block() {
             self.handle_block(block, nid);
         }
 
         if let Some(node) = self.nodes.get_mut(nid) {
-            match msg.payload.details {
+            match &msg.payload().details {
                 Details::SystemInterval(ref interval) => {
                     if interval.network_state.is_some() {
                         if let Some(raw) = raw {
@@ -350,7 +350,7 @@ impl Handler<UpdateNode> for Chain {
                     }
                 }
                 Details::AfgAuthoritySet(authority) => {
-                    node.set_validator_address(authority.authority_id);
+                    node.set_validator_address(authority.authority_id.clone());
                     self.broadcast();
                     return;
                 }
@@ -391,7 +391,7 @@ impl Handler<UpdateNode> for Chain {
                 _ => (),
             }
 
-            if let Some(block) = msg.payload.details.finalized_block() {
+            if let Some(block) = msg.payload().details.finalized_block() {
                 if let Some(finalized) = node.update_finalized(block) {
                     self.serializer.push(feed::FinalizedBlock(nid, finalized.height, finalized.hash));
 

--- a/backend/src/chain.rs
+++ b/backend/src/chain.rs
@@ -319,12 +319,12 @@ impl Handler<UpdateNode> for Chain {
     fn handle(&mut self, msg: UpdateNode, _: &mut Self::Context) {
         let UpdateNode { nid, msg, raw } = msg;
 
-        if let Some(block) = msg.payload().details.best_block() {
+        if let Some(block) = msg.details().best_block() {
             self.handle_block(block, nid);
         }
 
         if let Some(node) = self.nodes.get_mut(nid) {
-            match &msg.payload().details {
+            match msg.details() {
                 Details::SystemInterval(ref interval) => {
                     if interval.network_state.is_some() {
                         if let Some(raw) = raw {
@@ -391,7 +391,7 @@ impl Handler<UpdateNode> for Chain {
                 _ => (),
             }
 
-            if let Some(block) = msg.payload().details.finalized_block() {
+            if let Some(block) = msg.details().finalized_block() {
                 if let Some(finalized) = node.update_finalized(block) {
                     self.serializer.push(feed::FinalizedBlock(nid, finalized.height, finalized.hash));
 

--- a/backend/src/node/connector.rs
+++ b/backend/src/node/connector.rs
@@ -107,7 +107,7 @@ impl NodeConnector {
                 });
             }
             ConnMultiplex::Waiting { backlog } => {
-                if let Details::SystemConnected(connected) = &msg.payload().details {
+                if let Details::SystemConnected(connected) = msg.details() {
                     let mut node = connected.node.clone();
                     let rec = ctx.address().recipient();
 

--- a/backend/src/node/connector.rs
+++ b/backend/src/node/connector.rs
@@ -231,7 +231,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for NodeConnector {
             #[cfg(debug)]
             Err(err) => {
                 let data: &[u8] = data.get(..512).unwrap_or_else(|| &data);
-                warn!("Failed to parse node message: {} {}", err, std::str::from_utf8(data).unwrap_or_else(|_| "INVALID UTF8"))
+                log::warn!("Failed to parse node message: {} {}", err, std::str::from_utf8(data).unwrap_or_else(|_| "INVALID UTF8"))
             },
             #[cfg(not(debug))]
             Err(_) => (),

--- a/backend/src/node/connector.rs
+++ b/backend/src/node/connector.rs
@@ -10,7 +10,7 @@ use actix_http::ws::Item;
 use crate::aggregator::{Aggregator, AddNode};
 use crate::chain::{Chain, UpdateNode, RemoveNode};
 use crate::node::NodeId;
-use crate::node::message::{NodeMessage, Details};
+use crate::node::message::{NodeMessage, Payload};
 use crate::util::LocateRequest;
 use crate::types::ConnId;
 
@@ -107,7 +107,7 @@ impl NodeConnector {
                 });
             }
             ConnMultiplex::Waiting { backlog } => {
-                if let Details::SystemConnected(connected) = msg.details() {
+                if let Payload::SystemConnected(connected) = msg.payload() {
                     let mut node = connected.node.clone();
                     let rec = ctx.address().recipient();
 

--- a/backend/src/node/connector.rs
+++ b/backend/src/node/connector.rs
@@ -107,7 +107,7 @@ impl NodeConnector {
                 });
             }
             ConnMultiplex::Waiting { backlog } => {
-                if let Details::SystemConnected(connected) = msg.details {
+                if let Details::SystemConnected(connected) = msg.payload.details {
                     let SystemConnected { network_id: _, mut node } = connected;
                     let rec = ctx.address().recipient();
 

--- a/backend/src/node/connector.rs
+++ b/backend/src/node/connector.rs
@@ -10,7 +10,7 @@ use actix_http::ws::Item;
 use crate::aggregator::{Aggregator, AddNode};
 use crate::chain::{Chain, UpdateNode, RemoveNode};
 use crate::node::NodeId;
-use crate::node::message::{NodeMessage, Details, SystemConnected};
+use crate::node::message::{NodeMessage, Details};
 use crate::util::LocateRequest;
 use crate::types::ConnId;
 
@@ -96,7 +96,7 @@ impl NodeConnector {
     }
 
     fn handle_message(&mut self, msg: NodeMessage, data: Bytes, ctx: &mut <Self as Actor>::Context) {
-        let conn_id = msg.id.unwrap_or(0);
+        let conn_id = msg.id();
 
         match self.multiplex.entry(conn_id).or_default() {
             ConnMultiplex::Connected { nid, chain } => {
@@ -107,8 +107,8 @@ impl NodeConnector {
                 });
             }
             ConnMultiplex::Waiting { backlog } => {
-                if let Details::SystemConnected(connected) = msg.payload.details {
-                    let SystemConnected { network_id: _, mut node } = connected;
+                if let Details::SystemConnected(connected) = &msg.payload().details {
+                    let mut node = connected.node.clone();
                     let rec = ctx.address().recipient();
 
                     // FIXME: Use genesis hash instead of names to avoid this mess

--- a/backend/src/node/message.rs
+++ b/backend/src/node/message.rs
@@ -9,20 +9,23 @@ use crate::types::{Block, BlockNumber, BlockHash, ConnId};
 #[rtype(result = "()")]
 pub enum NodeMessage {
     V1 {
-      #[serde(flatten)]
-      payload: NodeMessagePayload,
+        ts: DateTime<Utc>,
+        #[serde(flatten)]
+        details: Details,
     },
     V2 {
-      id: ConnId,
-      payload: NodeMessagePayload,
+        id: ConnId,
+        ts: DateTime<Utc>,
+        #[serde(rename = "payload")]
+        details: Details,
     },
 }
 
 impl NodeMessage {
-    /// Returns a reference to the payload.
-    pub fn payload(&self) -> &NodeMessagePayload {
+    /// Returns a reference to the details.
+    pub fn details(&self) -> &Details {
         match self {
-            NodeMessage::V1 { payload } | NodeMessage::V2 { payload, .. } => payload,
+            NodeMessage::V1 { details, .. } | NodeMessage::V2 { details, .. } => details,
         }
     }
 
@@ -33,13 +36,13 @@ impl NodeMessage {
             NodeMessage::V2 { id, .. } => *id,
         }
     }
-}
 
-#[derive(Deserialize, Debug)]
-pub struct NodeMessagePayload {
-    pub ts: DateTime<Utc>,
-    #[serde(flatten)]
-    pub details: Details,
+    /// Returns the timestamp of the message.
+    pub fn ts(&self) -> &DateTime<Utc> {
+        match self {
+            NodeMessage::V1 { ts, .. } | NodeMessage::V2 { ts, .. } => ts,
+        }
+    }
 }
 
 #[derive(Deserialize, Debug)]

--- a/backend/src/node/message.rs
+++ b/backend/src/node/message.rs
@@ -8,8 +8,13 @@ use crate::types::{Block, BlockNumber, BlockHash, ConnId};
 #[derive(Deserialize, Debug, Message)]
 #[rtype(result = "()")]
 pub struct NodeMessage {
-    pub ts: DateTime<Utc>,
     pub id: Option<ConnId>,
+    pub payload: NodeMessagePayload,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct NodeMessagePayload {
+    pub ts: DateTime<Utc>,
     #[serde(flatten)]
     pub details: Details,
 }

--- a/backend/src/node/message.rs
+++ b/backend/src/node/message.rs
@@ -1,5 +1,4 @@
 use actix::prelude::*;
-use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use serde::de::IgnoredAny;
 use crate::node::NodeDetails;
@@ -9,13 +8,11 @@ use crate::types::{Block, BlockNumber, BlockHash, ConnId};
 #[rtype(result = "()")]
 pub enum NodeMessage {
     V1 {
-        ts: DateTime<Utc>,
         #[serde(flatten)]
         details: Details,
     },
     V2 {
         id: ConnId,
-        ts: DateTime<Utc>,
         #[serde(rename = "payload")]
         details: Details,
     },
@@ -34,13 +31,6 @@ impl NodeMessage {
         match self {
             NodeMessage::V1 { .. } => 0,
             NodeMessage::V2 { id, .. } => *id,
-        }
-    }
-
-    /// Returns the timestamp of the message.
-    pub fn ts(&self) -> &DateTime<Utc> {
-        match self {
-            NodeMessage::V1 { ts, .. } | NodeMessage::V2 { ts, .. } => ts,
         }
     }
 }

--- a/backend/src/node/message.rs
+++ b/backend/src/node/message.rs
@@ -7,9 +7,32 @@ use crate::types::{Block, BlockNumber, BlockHash, ConnId};
 
 #[derive(Deserialize, Debug, Message)]
 #[rtype(result = "()")]
-pub struct NodeMessage {
-    pub id: Option<ConnId>,
-    pub payload: NodeMessagePayload,
+pub enum NodeMessage {
+    V1 {
+      #[serde(flatten)]
+      payload: NodeMessagePayload,
+    },
+    V2 {
+      id: ConnId,
+      payload: NodeMessagePayload,
+    },
+}
+
+impl NodeMessage {
+    /// Returns a reference to the payload.
+    pub fn payload(&self) -> &NodeMessagePayload {
+        match self {
+            NodeMessage::V1 { payload } | NodeMessage::V2 { payload, .. } => payload,
+        }
+    }
+
+    /// Returns the connection ID or 0 if there is no ID.
+    pub fn id(&self) -> ConnId {
+        match self {
+            NodeMessage::V1 { .. } => 0,
+            NodeMessage::V2 { id, .. } => *id,
+        }
+    }
 }
 
 #[derive(Deserialize, Debug)]

--- a/backend/src/node/message.rs
+++ b/backend/src/node/message.rs
@@ -172,3 +172,32 @@ impl Payload {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_v1() {
+        let json = r#"{"msg":"notify.finalized","level":"INFO","ts":"2021-01-13T12:38:25.410794650+01:00","best":"0x031c3521ca2f9c673812d692fc330b9a18e18a2781e3f9976992f861fd3ea0cb","height":"50"}"#;
+        assert!(
+            matches!(
+                serde_json::from_str::<NodeMessage>(json).unwrap(),
+                NodeMessage::V1 { .. },
+            ),
+            "message did not match variant V1",
+        );
+    }
+
+    #[test]
+    fn message_v2() {
+        let json = r#"{"id":1,"ts":"2021-01-13T12:22:20.053527101+01:00","payload":{"best":"0xcc41708573f2acaded9dd75e07dac2d4163d136ca35b3061c558d7a35a09dd8d","height":"209","msg":"notify.finalized"}}"#;
+        assert!(
+            matches!(
+                serde_json::from_str::<NodeMessage>(json).unwrap(),
+                NodeMessage::V2 { .. },
+            ),
+            "message did not match variant V2",
+        );
+    }
+}

--- a/backend/src/node/message.rs
+++ b/backend/src/node/message.rs
@@ -9,20 +9,20 @@ use crate::types::{Block, BlockNumber, BlockHash, ConnId};
 pub enum NodeMessage {
     V1 {
         #[serde(flatten)]
-        details: Details,
+        payload: Payload,
     },
     V2 {
         id: ConnId,
         #[serde(rename = "payload")]
-        details: Details,
+        payload: Payload,
     },
 }
 
 impl NodeMessage {
-    /// Returns a reference to the details.
-    pub fn details(&self) -> &Details {
+    /// Returns a reference to the payload.
+    pub fn payload(&self) -> &Payload {
         match self {
-            NodeMessage::V1 { details, .. } | NodeMessage::V2 { details, .. } => details,
+            NodeMessage::V1 { payload, .. } | NodeMessage::V2 { payload, .. } => payload,
         }
     }
 
@@ -37,7 +37,7 @@ impl NodeMessage {
 
 #[derive(Deserialize, Debug)]
 #[serde(tag = "msg")]
-pub enum Details {
+pub enum Payload {
     #[serde(rename = "node.start")]
     NodeStart(Block),
     #[serde(rename = "system.connected")]
@@ -145,24 +145,24 @@ impl Block {
     }
 }
 
-impl Details {
+impl Payload {
     pub fn best_block(&self) -> Option<&Block> {
         match self {
-            Details::BlockImport(block) => Some(block),
-            Details::SystemInterval(SystemInterval { block, .. }) => block.as_ref(),
+            Payload::BlockImport(block) => Some(block),
+            Payload::SystemInterval(SystemInterval { block, .. }) => block.as_ref(),
             _ => None,
         }
     }
 
     pub fn finalized_block(&self) -> Option<Block> {
         match self {
-            Details::SystemInterval(ref interval) => {
+            Payload::SystemInterval(ref interval) => {
                 Some(Block {
                     hash: interval.finalized_hash?,
                     height: interval.finalized_height?,
                 })
             },
-            Details::NotifyFinalized(ref finalized) => {
+            Payload::NotifyFinalized(ref finalized) => {
                 Some(Block {
                     hash: finalized.hash,
                     height: finalized.height.parse().ok()?

--- a/backend/src/node/message.rs
+++ b/backend/src/node/message.rs
@@ -38,8 +38,6 @@ impl NodeMessage {
 #[derive(Deserialize, Debug)]
 #[serde(tag = "msg")]
 pub enum Payload {
-    #[serde(rename = "node.start")]
-    NodeStart(Block),
     #[serde(rename = "system.connected")]
     SystemConnected(SystemConnected),
     #[serde(rename = "system.interval")]

--- a/backend/src/node/message.rs
+++ b/backend/src/node/message.rs
@@ -6,6 +6,7 @@ use crate::types::{Block, BlockNumber, BlockHash, ConnId};
 
 #[derive(Deserialize, Debug, Message)]
 #[rtype(result = "()")]
+#[serde(untagged)]
 pub enum NodeMessage {
     V1 {
         #[serde(flatten)]
@@ -13,7 +14,6 @@ pub enum NodeMessage {
     },
     V2 {
         id: ConnId,
-        #[serde(rename = "payload")]
         payload: Payload,
     },
 }

--- a/backend/src/types.rs
+++ b/backend/src/types.rs
@@ -10,7 +10,7 @@ pub type Timestamp = u64;
 pub type Address = Box<str>;
 pub use primitive_types::H256 as BlockHash;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct NodeDetails {
     pub chain: Box<str>,
     pub name: Box<str>,


### PR DESCRIPTION
Wraps the node's message content into another object so the ID of the connection is separated from the actual payload.