### PR TITLE
Why can't you just be normal?

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 #### BUILDER IMAGE -- quite big one ####
-FROM paritytech/musl-ci-linux as builder
+FROM paritytech/ci-linux:production as builder
 LABEL maintainer="Daniel Maricic daniel@woss.io"
 LABEL description="Polkadot Telemetry backend builder image"
 


### PR DESCRIPTION
remove musl image and replace with the maintained CI Rust image for now.