### PR TITLE
Mute denied nodes

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -589,6 +589,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "ctor"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1726,9 +1736,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "f3a1d708c221c5a612956ef9f75b37e454e88d1f7b899fbd3a18d4252012d663"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1752,8 +1762,8 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "ctor",
  "fnv",
- "lazy_static",
  "log",
  "num-traits",
  "parking_lot",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -23,7 +23,7 @@ parking_lot = "0.11"
 reqwest = { version = "0.11.1", features = ["blocking", "json"] }
 rustc-hash = "1.1.0"
 clap = "3.0.0-beta.2"
-lazy_static = "1"
+ctor = "0.1.20"
 
 [profile.release]
 lto = true

--- a/backend/src/aggregator.rs
+++ b/backend/src/aggregator.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use actix::prelude::*;
 use actix_web_actors::ws::{CloseReason, CloseCode};
-use lazy_static::lazy_static;
+use ctor::ctor;
 
 use crate::node::connector::{Mute, NodeConnector};
 use crate::feed::connector::{FeedConnector, Connected, FeedId};
@@ -30,20 +30,20 @@ pub struct ChainEntry {
     max_nodes: usize,
 }
 
-lazy_static! {
-    /// Labels of chains we consider "first party". These chains allow any
-    /// number of nodes to connect.
-    static ref FIRST_PARTY_NETWORKS: HashSet<&'static str> = {
-        let mut set = HashSet::new();
-        set.insert("Polkadot");
-        set.insert("Kusama");
-        set.insert("Westend");
-        set.insert("Rococo");
-        set
-    };
-}
+#[ctor]
+/// Labels of chains we consider "first party". These chains allow any
+/// number of nodes to connect.
+static FIRST_PARTY_NETWORKS: HashSet<&'static str> = {
+    let mut set = HashSet::new();
+    set.insert("Polkadot");
+    set.insert("Kusama");
+    set.insert("Westend");
+    set.insert("Rococo");
+    set
+};
+
 /// Max number of nodes allowed to connect to the telemetry server.
-const THIRD_PARTY_NETWORKS_MAX_NODES: usize = 2;
+const THIRD_PARTY_NETWORKS_MAX_NODES: usize = 500;
 
 impl Aggregator {
     pub fn new(denylist: HashSet<String>) -> Self {

--- a/backend/src/aggregator.rs
+++ b/backend/src/aggregator.rs
@@ -219,7 +219,7 @@ impl Handler<AddNode> for Aggregator {
         } else {
             log::warn!(target: "Aggregator::AddNode", "Chain {} is over quota ({})", chain.label, chain.max_nodes);
             let reason = CloseReason{ code: CloseCode::Again, description: Some("Overquota".into()) };
-            let _ = mute.do_send(Mute { reason });
+            let _ = rec.do_send(Mute { reason });
         }
     }
 }

--- a/backend/src/aggregator.rs
+++ b/backend/src/aggregator.rs
@@ -205,7 +205,7 @@ impl Handler<AddNode> for Aggregator {
             let _ = mute.do_send(Mute { reason });
             return;
         }
-        let AddNode { node, conn_id, rec, mute } = msg;
+        let AddNode { node, conn_id, rec } = msg;
         log::trace!(target: "Aggregator::AddNode", "New node connected. Chain '{}'", node.chain);
 
         let cid = self.lazy_chain(&node.chain, ctx);

--- a/backend/src/aggregator.rs
+++ b/backend/src/aggregator.rs
@@ -131,7 +131,7 @@ pub struct AddNode {
     /// Connection id used by the node connector for multiplexing parachains
     pub conn_id: ConnId,
     /// Recipient for the initialization message
-    pub rec: Recipient<Initialize>,
+    pub rec: Addr<NodeConnector>,
     /// Recipient for the mute message
     pub mute: Recipient<Mute>,
 }

--- a/backend/src/chain.rs
+++ b/backend/src/chain.rs
@@ -284,7 +284,7 @@ impl Chain {
         if node.update_block(*block) {
             if block.height > self.best.height {
                 self.best = *block;
-                log::info!(
+                log::debug!(
                     "[{}] [nodes={}/feeds={}] new best block={}/{:?}",
                     self.label.0,
                     nodes_len,

--- a/backend/src/node/connector.rs
+++ b/backend/src/node/connector.rs
@@ -90,6 +90,7 @@ impl NodeConnector {
             // check client heartbeats
             if Instant::now().duration_since(act.hb) > CLIENT_TIMEOUT {
                 // stop actor
+                ctx.close(Some(CloseReason { code: ws::CloseCode::Abnormal, description: Some("Missed heartbeat".into())}));
                 ctx.stop();
             }
         });
@@ -113,11 +114,6 @@ impl NodeConnector {
                     match &*node.chain {
                         "Kusama CC3" => node.chain = "Kusama".into(),
                         "Polkadot CC1" => node.chain = "Polkadot".into(),
-                        "Earth" => {
-                            // Temp, there is too many of them
-                            ctx.stop();
-                            return;
-                        },
                         _ => ()
                     }
 

--- a/backend/src/node/connector.rs
+++ b/backend/src/node/connector.rs
@@ -121,8 +121,7 @@ impl NodeConnector {
                         _ => ()
                     }
 
-                    let rec = ctx.address();
-                    self.aggregator.do_send(AddNode { node, conn_id, rec });
+                    self.aggregator.do_send(AddNode { node, conn_id, node_connector: ctx.address() });
                 } else {
                     if backlog.len() >= 10 {
                         backlog.remove(0);

--- a/backend/src/node/connector.rs
+++ b/backend/src/node/connector.rs
@@ -121,10 +121,8 @@ impl NodeConnector {
                         _ => ()
                     }
 
-                    let rec = ctx.address().recipient();
-                    let mute = ctx.address().recipient();
-
-                    self.aggregator.do_send(AddNode { node, conn_id, rec, mute });
+                    let rec = ctx.address();
+                    self.aggregator.do_send(AddNode { node, conn_id, rec });
                 } else {
                     if backlog.len() >= 10 {
                         backlog.remove(0);

--- a/backend/src/node/connector.rs
+++ b/backend/src/node/connector.rs
@@ -24,7 +24,7 @@ const CONT_BUF_LIMIT: usize = 10 * 1024 * 1024;
 pub struct NodeConnector {
     /// Multiplexing connections by id
     multiplex: BTreeMap<ConnId, ConnMultiplex>,
-    /// Client must send ping at least once per 10 seconds (CLIENT_TIMEOUT),
+    /// Client must send ping at least once every 60 seconds (CLIENT_TIMEOUT),
     hb: Instant,
     /// Aggregator actor address
     aggregator: Addr<Aggregator>,


### PR DESCRIPTION
When a node is not allowed to connect, send a `Mute` message to `NodeConnector`.

A node can be disallowed to connect if the chain is over-quota or if the whole chain is banned, i.e. on the denylist.

Also dials down the logging of latest finalized block from `info` to `debug`.
