### PR TITLE
Switch away from using MUSL builds

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,14 +1,14 @@
-FROM rust:alpine as builder
+FROM paritytech/ci-linux:production as builder
 
 ARG PROFILE=release
 WORKDIR /app
 
 COPY . .
 
-RUN apk add musl-dev openssl-dev; cargo build --${PROFILE} --bins
+RUN cargo build --${PROFILE} --bins
 
 # MAIN IMAGE FOR PEOPLE TO PULL --- small one#
-FROM scratch
+FROM debian:buster-slim
 LABEL maintainer="Parity Technologies"
 LABEL description="Polkadot Telemetry backend, static build"
 
@@ -17,6 +17,7 @@ WORKDIR /usr/local/bin
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/target/$PROFILE/telemetry /usr/local/bin
+RUN apt-get -y update && apt-get -y install openssl && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/
 
 EXPOSE 8000
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,15 +1,11 @@
-#### BUILDER IMAGE -- quite big one ####
-FROM paritytech/musl-ci-linux:latest as builder
-LABEL maintainer="Parity Technologies"
-LABEL description="Polkadot Telemetry backend builder image"
+FROM rust:alpine as builder
 
 ARG PROFILE=release
 WORKDIR /app
 
 COPY . .
 
-RUN cargo build --${PROFILE} --bins --target x86_64-unknown-linux-musl
-
+RUN apk add musl-dev openssl-dev; cargo build --${PROFILE} --bins
 
 # MAIN IMAGE FOR PEOPLE TO PULL --- small one#
 FROM scratch
@@ -20,7 +16,7 @@ ARG PROFILE=release
 WORKDIR /usr/local/bin
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/$PROFILE/telemetry /usr/local/bin
+COPY --from=builder /app/target/$PROFILE/telemetry /usr/local/bin
 
 EXPOSE 8000
 


### PR DESCRIPTION
Until we have a working MUSL setup, just switch to using dynamically linked, 'normal' build. This is just to get the thing working again.