### PR TITLE
listen on external interfaces in docker container

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,4 +21,4 @@ RUN apt-get -y update && apt-get -y install openssl && apt-get autoremove -y && 
 
 EXPOSE 8000
 
-ENTRYPOINT ["telemetry"]
+ENTRYPOINT ["telemetry", "--listen", "0.0.0.0:8000"]


### PR DESCRIPTION
by default backed is only listening on localhost by default, this means that backend is unavailable to other docker containers and cannot be exposed if you attach the container to some network (in docker swarm by example).