### PR TITLE
Set telemetry to listen on all interfaces by default in the backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,4 +21,4 @@ RUN apt-get -y update && apt-get -y install openssl && apt-get autoremove -y && 
 
 EXPOSE 8000
 
-ENTRYPOINT ["telemetry"]
+ENTRYPOINT ["telemetry", "--listen", "0.0.0.0:8000"]


### PR DESCRIPTION
Added telemetry's parameters for correct launch backend in docker-compose