### PR TITLE
Listen on all interfaces from the backend container by default

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,4 +21,4 @@ RUN apt-get -y update && apt-get -y install openssl && apt-get autoremove -y && 
 
 EXPOSE 8000
 
-ENTRYPOINT ["telemetry"]
+ENTRYPOINT ["telemetry", "--listen", "0.0.0.0:8000"]


### PR DESCRIPTION
When running in Docker, the backend listens to :8000 but on 127.0.0.1 by default.
This is not very useful when using docker unless users make the unsafer choice to use their host network.

This PR allows listening on "all" interfaces (inside the container...) so that requests from the outside of the container do reach :8000 by default.