### PR TITLE
exposing the shard service to the internet

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -44,8 +44,6 @@ service:
     port: 80
     targetPort: 8000
     annotations:
-      cloud.google.com/load-balancer-type: Internal
-      networking.gke.io/internal-load-balancer-allow-global-access: "true"
       external-dns.alpha.kubernetes.io/hostname: substrate-telemetry.parity-stg.parity.io.
   core:
     type: LoadBalancer


### PR DESCRIPTION
the shard load balancer needs to be exposed to the internet so VMs from different networks would be able to connect to it without doing peering between projects.