### PR TITLE
adding values-parity.yaml to the project again

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ stages:
     - |-
       helm repo add parity https://paritytech.github.io/helm-charts/
       helm repo update
-      kubectl get cm helm-custom-values -n substrate-telemetry -o jsonpath='{.data.values-parity\.yaml}' > values-parity.yaml
+      kubectl get cm helm-custom-values -n $KUBE_NAMESPACE -o jsonpath='{.data.values-parity\.yaml}' > values-parity.yaml
     - helm upgrade
         --install
         --atomic


### PR DESCRIPTION
@chevdor According to your comment on https://github.com/paritytech/substrate-telemetry/issues/370#issue-971582423, I moved the parity's values file to the [could-infra repository](https://gitlab.parity.io/parity/infrastructure/cloud-infra/-/blob/master/parity-stg/kubernetes/helm/substrate-telemetry/values-parity.yaml), but the CI stopped working because the `substrate-telemetry` Gitlab repository doesn't have access to read the files from `cloud-infra`. For granting access, an access token should be configured for `substrate-telemetry` repository to be able to fetch files from the `cloud-infra`, but it might have its own security concerns again.

I would suggest leaving it like this for now to have at least a working CI pipeline then I would consult with Gabriel about this specific project and once we find the proper solution, we would remove the file from here again.