### PR TITLE
removing the default nginx configuration

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -32,7 +32,8 @@ RUN apk add --no-cache bash && \
     chown -R nginx:nginx /var/log/nginx && \
     chown -R nginx:nginx /etc/nginx/conf.d && \
     touch /var/run/nginx.pid && \
-    chown -R nginx:nginx /var/run/nginx.pid
+    chown -R nginx:nginx /var/run/nginx.pid && \
+    rm /etc/nginx/conf.d/default.conf
 
 # UID= 101
 USER nginx


### PR DESCRIPTION
nginx by default listens on port 80 and it's not allowed in Kubernetes when the pod is not running in privileged mode.
The default configuration has been removed as all of the options already exists in our custom `nginx.conf` (`/etc/nginx/nginx.conf`)