### PR TITLE
Improve logging and error reporting around IP and location info

### DIFF
--- a/backend/telemetry_shard/src/main.rs
+++ b/backend/telemetry_shard/src/main.rs
@@ -143,7 +143,11 @@ async fn start_server(opts: Opts) -> anyhow::Result<()> {
                     Ok(http_utils::upgrade_to_websocket(
                         req,
                         move |ws_send, ws_recv| async move {
-                            log::info!("Opening /submit connection from {:?} (address source: {})", real_addr, real_addr_source);
+                            log::info!(
+                                "Opening /submit connection from {:?} (address source: {})",
+                                real_addr,
+                                real_addr_source
+                            );
                             let tx_to_aggregator = aggregator.subscribe_node();
                             let (mut tx_to_aggregator, mut ws_send) =
                                 handle_node_websocket_connection(
@@ -156,7 +160,11 @@ async fn start_server(opts: Opts) -> anyhow::Result<()> {
                                     block_list,
                                 )
                                 .await;
-                            log::info!("Closing /submit connection from {:?} (address source: {})", real_addr, real_addr_source);
+                            log::info!(
+                                "Closing /submit connection from {:?} (address source: {})",
+                                real_addr,
+                                real_addr_source
+                            );
                             // Tell the aggregator that this connection has closed, so it can tidy up.
                             let _ = tx_to_aggregator.send(FromWebsocket::Disconnected).await;
                             let _ = ws_send.close().await;

--- a/backend/telemetry_shard/src/real_ip.rs
+++ b/backend/telemetry_shard/src/real_ip.rs
@@ -47,7 +47,7 @@ pub enum Source {
     ForwardedHeader,
     XForwardedForHeader,
     XRealIpHeader,
-    SocketAddr
+    SocketAddr,
 }
 
 impl std::fmt::Display for Source {
@@ -83,12 +83,10 @@ fn pick_best_ip_from_options(
         })
         .or_else(|| {
             // fall back to X-Forwarded-For
-            forwarded_for
-                .as_ref()
-                .and_then(|val| {
-                    let addr = get_first_addr_from_x_forwarded_for_header(val)?;
-                    Some((addr, Source::XForwardedForHeader))
-                })
+            forwarded_for.as_ref().and_then(|val| {
+                let addr = get_first_addr_from_x_forwarded_for_header(val)?;
+                Some((addr, Source::XForwardedForHeader))
+            })
         })
         .or_else(|| {
             // fall back to X-Real-IP
@@ -100,7 +98,8 @@ fn pick_best_ip_from_options(
         .and_then(|(ip, source)| {
             // Try parsing assuming it may have a port first,
             // and then assuming it doesn't.
-            let addr = ip.parse::<SocketAddr>()
+            let addr = ip
+                .parse::<SocketAddr>()
                 .map(|s| s.ip())
                 .or_else(|_| ip.parse::<IpAddr>())
                 .ok()?;


### PR DESCRIPTION
Primarily some small tweaks so that when a node connects, we can see where their IP address is derived from, eg:

```
2021-08-27 14:58:57,235 INFO  [telemetry_shard] Closing /submit connection from 10.1.12.21 (address source: 'X-Real-Ip' header)
```

On failure to obtain location information, we get some logging as to what went wrong, eg:

```
2021-08-27 14:58:53,562 WARN  [telemetry_core::find_location] Couldn't obtain location information for 10.1.12.21 from ipapi.co: Failed to decode '{"error": true, "reason": "RateLimited", "message": "Visit: https://ipapi.co/ratelimited/ "}'
2021-08-27 14:58:53,685 WARN  [telemetry_core::find_location] Couldn't obtain location information for 10.1.12.21 from ipinfo.co: Failed to decode '{
  "ip": "10.1.12.21",
  "bogon": true
}'
```

(it's a shame about the newlines, but I thought that printing the response body verbatim was rather useful).

Errors obtaining location were previously cached. I've removed this, so if a node reconnects we'll try and obtain its location again if we failed last time. The pro of this is that if the request was rate limited or thelocation service down, we might succeed next time. The con is that a node with an invalid IP address that reconnects frequently might cause us to be rate limited.

Manual testing can be done using `websocat`:

```
% echo '{"id":1,"ts":"2021-07-12T10:37:47.714666+01:00","payload":{"authority":true,"chain":"Local Testnet","config":"","genesis_hash":"0x1122334455667788990011223344556677889900112233445566778899001122","implementation":"Substrate Node","msg":"system.connected","name":"Alice","network_id":"12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp","startup_time":"1625565542717","version":"2.0.0-07a1af348-aarch64-macos"}}' | websocat ws://localhost:8001/submit -H 'X-Real-Ip: 10.1.12.21' -n
```

Just tweak that header at the end (or remove it) to see the shard spotting where the address came from and the location in the UI being reported accurately or not.