### PR TITLE
Make `Tooltip` as a function component with react hooks

### DIFF
--- a/frontend/src/components/Consensus/ConsensusBlock.tsx
+++ b/frontend/src/components/Consensus/ConsensusBlock.tsx
@@ -125,9 +125,8 @@ export class ConsensusBlock extends React.Component<ConsensusBlock.Props, {}> {
                   className="legend"
                   key={'block_row_' + this.props.height + '_legend'}
                 >
-                  <Tooltip text={`Block number: ${this.props.height}`}>
-                    {this.displayBlockNumber()}
-                  </Tooltip>
+                  <Tooltip text={`Block number: ${this.props.height}`} />
+                  {this.displayBlockNumber()}
                 </th>
                 <th
                   className="finalizedInfo"


### PR DESCRIPTION
While trying to read the code base, I found most of the components are class component with `shouldComponentUpdate` (a.k.a `sCU`) but I wonder maybe some of them don't need the `sCU` and can be simplified as a function component.

For example, in class component based `Tooltip`, it checks `this.props.text !== nextProps.text || this.state.copied !== nextState.copied` in its `sCU`.
In React, it should already help us to trigger re-render when a prop is changed. So, we're using class components in other places, the component will always pass the same references for the callbacks (e.g. `onInit` or `onCopy`) so it should not trigger a re-render. and it should also trigger a re-render when the `text` is changed.
Also, for the `copied` state, with moving to use `React.useState`, the hooks will help us to memoize the value of the state and only trigger re-render when the state is updated.

I wonder if this improves the component and also simplify it (like with using `useRef`, we don't need to set the ref manually). Also, thanks to using function component, I found there's a redundant children in `ConsensusBlock` which might be missed to remove in [this commit](https://github.com/paritytech/substrate-telemetry/commit/ebb01c1a7db55e2bcef6059a3f3fac64f4996941#diff-108d51161fdfef38740aed57b0e10e034fb75ba6553fa071931b3eb21bb877d4L71-L76).

**Question**: Not sure if we actually need to render the children of Tooltip ☝️ , or it's just missed to be removed in [the commit](https://github.com/paritytech/substrate-telemetry/commit/ebb01c1a7db55e2bcef6059a3f3fac64f4996941#diff-108d51161fdfef38740aed57b0e10e034fb75ba6553fa071931b3eb21bb877d4L71-L76)?

Please feel free to let me know if this makes sense to you 🙏  