### PR TITLE
Bump tokio to 1.10 and add a test

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1734,9 +1734,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.8.2"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2602b8af3767c285202012822834005f596c811042315fa7e9f5b12b2a43207"
+checksum = "92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5"
 dependencies = [
  "autocfg",
  "bytes",

--- a/backend/common/src/rolling_total.rs
+++ b/backend/common/src/rolling_total.rs
@@ -198,6 +198,26 @@ mod test {
     use super::*;
 
     #[test]
+    fn deosnt_grow_beyond_window_size() {
+        let start_time = Instant::now();
+        let granularity = Duration::from_secs(1);
+        let mut rolling_total = RollingTotalBuilder::new()
+            .granularity(granularity)
+            .window_size_multiple(3) // There should be no more than 3 buckets ever,
+            .time_source(UserTimeSource(start_time))
+            .start();
+
+        for n in 0..1_000 {
+            rolling_total.push(n);
+            rolling_total
+                .time_source()
+                .increment_by(Duration::from_millis(300)); // multiple values per granularity.
+        }
+
+        assert_eq!(rolling_total.averages().len(), 3);
+    }
+
+    #[test]
     fn times_grouped_by_granularity_spacing() {
         let start_time = Instant::now();
         let granularity = Duration::from_secs(1);

--- a/backend/telemetry_core/Cargo.toml
+++ b/backend/telemetry_core/Cargo.toml
@@ -31,7 +31,7 @@ smallvec = "1.6.1"
 soketto = "0.6.0"
 structopt = "0.3.21"
 thiserror = "1.0.25"
-tokio = { version = "1.7.0", features = ["full"] }
+tokio = { version = "1.10.1", features = ["full"] }
 tokio-util = { version = "0.6", features = ["compat"] }
 
 [dev-dependencies]

--- a/backend/telemetry_shard/Cargo.toml
+++ b/backend/telemetry_shard/Cargo.toml
@@ -23,5 +23,5 @@ simple_logger = "1.11.0"
 soketto = "0.6.0"
 structopt = "0.3.21"
 thiserror = "1.0.25"
-tokio = { version = "1.7.0", features = ["full"] }
+tokio = { version = "1.10.1", features = ["full"] }
 tokio-util = { version = "0.6", features = ["compat"] }

--- a/backend/test_utils/Cargo.toml
+++ b/backend/test_utils/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4.14"
 serde_json = "1.0.64"
 soketto = "0.6.0"
 thiserror = "1.0.25"
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.10.1", features = ["full"] }
 tokio-util = { version = "0.6.7", features = ["full"] }
 common = { path = "../common" }
 time = { version = "0.3.0", features = ["formatting"] }


### PR DESCRIPTION
The changelog for Tokio 1.10 suggests a small memory leak fix (as well as a few bugs and such fixed), so I thought it worth bumping the version and seeing whether this has any impact on the gradual memory growth spotted in shards.