### PR TITLE
Make soak tests work again now that we subscribe by genesis hash

### DIFF
--- a/backend/telemetry_core/tests/soak_tests.rs
+++ b/backend/telemetry_core/tests/soak_tests.rs
@@ -116,9 +116,8 @@ async fn run_soak_test(opts: SoakTestOpts) {
         nodes.append(&mut conns);
     }
 
-    // TODO: Derive the str form the BlockHash.
     let genesis_hash = BlockHash::from_low_u64_be(1);
-    let genesis_hash_str = "0x0000000000000000000000000000000000000000000000000000000000000001";
+    let genesis_hash_str = format!("{:0x}", genesis_hash);
 
     // Start nodes talking to the shards:
     let bytes_in = Arc::new(AtomicUsize::new(0));

--- a/backend/telemetry_core/tests/soak_tests.rs
+++ b/backend/telemetry_core/tests/soak_tests.rs
@@ -34,8 +34,8 @@ In general, if you run into issues, it may be better to run this on a linux
 box; MacOS seems to hit limits quicker in general.
 */
 
-use common::ws_client::SentMessage;
 use common::node_types::BlockHash;
+use common::ws_client::SentMessage;
 use futures::{future, StreamExt};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;

--- a/backend/telemetry_core/tests/soak_tests.rs
+++ b/backend/telemetry_core/tests/soak_tests.rs
@@ -161,7 +161,9 @@ async fn run_soak_test(opts: SoakTestOpts) {
 
     // Every feed subscribes to the chain above to recv messages about it:
     for (feed_tx, _) in &mut feeds {
-        feed_tx.send_command("subscribe", &genesis_hash_string).unwrap();
+        feed_tx
+            .send_command("subscribe", &genesis_hash_string)
+            .unwrap();
     }
 
     // Also start receiving messages, counting the bytes received so far.

--- a/backend/telemetry_core/tests/soak_tests.rs
+++ b/backend/telemetry_core/tests/soak_tests.rs
@@ -117,7 +117,7 @@ async fn run_soak_test(opts: SoakTestOpts) {
     }
 
     let genesis_hash = BlockHash::from_low_u64_be(1);
-    let genesis_hash_str = format!("{:0x}", genesis_hash);
+    let genesis_hash_string = format!("{:0x}", genesis_hash);
 
     // Start nodes talking to the shards:
     let bytes_in = Arc::new(AtomicUsize::new(0));
@@ -161,7 +161,7 @@ async fn run_soak_test(opts: SoakTestOpts) {
 
     // Every feed subscribes to the chain above to recv messages about it:
     for (feed_tx, _) in &mut feeds {
-        feed_tx.send_command("subscribe", genesis_hash_str).unwrap();
+        feed_tx.send_command("subscribe", &genesis_hash_string).unwrap();
     }
 
     // Also start receiving messages, counting the bytes received so far.

--- a/backend/test_utils/src/fake_telemetry.rs
+++ b/backend/test_utils/src/fake_telemetry.rs
@@ -8,22 +8,14 @@ use tokio::time::{self, MissedTickBehavior};
 /// This emits fake but realistic looking telemetry messages.
 /// Can be connected to a telemetry server to emit realistic messages.
 pub struct FakeTelemetry {
-    block_time: Duration,
-    node_name: String,
-    chain: String,
-    message_id: usize,
+    pub block_time: Duration,
+    pub node_name: String,
+    pub chain: String,
+    pub genesis_hash: BlockHash,
+    pub message_id: usize,
 }
 
 impl FakeTelemetry {
-    pub fn new(block_time: Duration, node_name: String, chain: String, message_id: usize) -> Self {
-        Self {
-            block_time,
-            node_name,
-            chain,
-            message_id,
-        }
-    }
-
     /// Begin emitting messages from this node, calling the provided callback each
     /// time a new message is emitted.
     // Unused assignments allowed because macro seems to mess with knowledge of what's
@@ -38,6 +30,7 @@ impl FakeTelemetry {
         let id = self.message_id;
         let name = self.node_name;
         let chain = self.chain;
+        let genesis_hash = self.genesis_hash;
         let block_time = self.block_time;
 
         // Our "state". These numbers can be hashed to give a block hash,
@@ -62,7 +55,7 @@ impl FakeTelemetry {
                 "authority":true,
                 "chain":chain,
                 "config":"",
-                "genesis_hash":block_hash(best_block_n),
+                "genesis_hash":genesis_hash,
                 "implementation":"Substrate Node",
                 "msg":"system.connected",
                 "name":name,


### PR DESCRIPTION
A small fix to the soak tests to make them work again using genesis hash to subscribe.