### PR TITLE
Tidy up stale connections.

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -31,6 +31,9 @@ name = "arrayvec"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "atty"
@@ -198,6 +201,7 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "base64",
  "bimap",
  "bincode",

--- a/backend/common/Cargo.toml
+++ b/backend/common/Cargo.toml
@@ -28,6 +28,7 @@ soketto = "0.6.0"
 thiserror = "1.0.24"
 tokio = { version = "1.8.2", features = ["full"] }
 tokio-util = { version = "0.6", features = ["compat"] }
+arrayvec = { version = "0.7.1", features = ["serde"] }
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/backend/common/src/node_message.rs
+++ b/backend/common/src/node_message.rs
@@ -141,6 +141,7 @@ impl Payload {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrayvec::ArrayString;
     use bincode::Options;
 
     // Without adding a derive macro and marker trait (and enforcing their use), we don't really
@@ -166,7 +167,7 @@ mod tests {
                     implementation: "foo".into(),
                     version: "foo".into(),
                     validator: None,
-                    network_id: None,
+                    network_id: ArrayString::new(),
                     startup_time: None,
                 },
             }),

--- a/backend/common/src/node_types.rs
+++ b/backend/common/src/node_types.rs
@@ -19,12 +19,14 @@
 
 use serde::ser::{SerializeTuple, Serializer};
 use serde::{Deserialize, Serialize};
+use arrayvec::ArrayString;
 
 use crate::{time, MeanList};
 
 pub type BlockNumber = u64;
 pub type Timestamp = u64;
 pub use primitive_types::H256 as BlockHash;
+pub type NetworkId = ArrayString<64>;
 
 /// Basic node details.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -34,7 +36,7 @@ pub struct NodeDetails {
     pub implementation: Box<str>,
     pub version: Box<str>,
     pub validator: Option<Box<str>>,
-    pub network_id: Option<Box<str>>,
+    pub network_id: NetworkId,
     pub startup_time: Option<Box<str>>,
 }
 

--- a/backend/common/src/node_types.rs
+++ b/backend/common/src/node_types.rs
@@ -17,9 +17,9 @@
 //! These types are partly used in [`crate::node_message`], but also stored and used
 //! more generally through the application.
 
+use arrayvec::ArrayString;
 use serde::ser::{SerializeTuple, Serializer};
 use serde::{Deserialize, Serialize};
-use arrayvec::ArrayString;
 
 use crate::{time, MeanList};
 

--- a/backend/telemetry_core/src/state/state.rs
+++ b/backend/telemetry_core/src/state/state.rs
@@ -274,6 +274,7 @@ impl<'a> StateChain<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use common::node_types::NetworkId;
 
     fn node(name: &str, chain: &str) -> NodeDetails {
         NodeDetails {
@@ -282,7 +283,7 @@ mod test {
             implementation: "Bar".into(),
             version: "0.1".into(),
             validator: None,
-            network_id: None,
+            network_id: NetworkId::new(),
             startup_time: None,
         }
     }

--- a/backend/telemetry_core/tests/e2e_tests.rs
+++ b/backend/telemetry_core/tests/e2e_tests.rs
@@ -657,7 +657,7 @@ async fn e2e_slow_feeds_are_disconnected() {
     let (mut raw_feed_tx, mut raw_feed_rx) = server.get_core().connect_feed_raw().await.unwrap();
 
     // Subscribe the feed:
-    raw_feed_tx.send_text("subscribe:Polkadot").await.unwrap();
+    raw_feed_tx.send_text("subscribe:0x0000000000000000000000000000000000000000000000000000000000000001").await.unwrap();
 
     // Wait a little.. the feed hasn't been receiving messages so it should
     // be booted after ~a second.

--- a/backend/telemetry_shard/src/aggregator.rs
+++ b/backend/telemetry_shard/src/aggregator.rs
@@ -250,13 +250,8 @@ impl Aggregator {
                     let _ = tx_to_telemetry_core
                         .send_async(FromShardAggregator::UpdateNode { local_id, payload })
                         .await;
-                },
-                ToAggregator::FromWebsocket(
-                    conn_id,
-                    FromWebsocket::Remove {
-                        message_id
-                    }
-                ) => {
+                }
+                ToAggregator::FromWebsocket(conn_id, FromWebsocket::Remove { message_id }) => {
                     // Get the local ID, ignoring the message if none match:
                     let local_id = match to_local_id.get_id(&(conn_id, message_id)) {
                         Some(id) => id,
@@ -271,7 +266,7 @@ impl Aggregator {
                     let _ = tx_to_telemetry_core
                         .send_async(FromShardAggregator::RemoveNode { local_id })
                         .await;
-                },
+                }
                 ToAggregator::FromWebsocket(disconnected_conn_id, FromWebsocket::Disconnected) => {
                     // Find all of the local IDs corresponding to the disconnected connection ID and
                     // remove them, telling Telemetry Core about them too. This could be more efficient,

--- a/backend/telemetry_shard/src/json_message/node_message.rs
+++ b/backend/telemetry_shard/src/json_message/node_message.rs
@@ -246,7 +246,7 @@ pub struct NodeDetails {
     pub implementation: Box<str>,
     pub version: Box<str>,
     pub validator: Option<Box<str>>,
-    pub network_id: Option<Box<str>>,
+    pub network_id: node_types::NetworkId,
     pub startup_time: Option<Box<str>>,
 }
 

--- a/backend/telemetry_shard/src/main.rs
+++ b/backend/telemetry_shard/src/main.rs
@@ -243,9 +243,6 @@ where
         return (tx_to_aggregator, ws_send);
     }
 
-    // A periodic interval to check for stale nodes.
-    let mut stale_interval = tokio::time::interval(stale_node_timeout / 2);
-
     // Receiving data isn't cancel safe, so let it happen in a separate task.
     // If this loop ends, the outer will receive a `None` message and end too.
     // If the outer loop ends, it fires a msg on `close_connection_rx` to ensure this ends too.
@@ -277,6 +274,9 @@ where
             }
         }
     });
+
+    // A periodic interval to check for stale nodes.
+    let mut stale_interval = tokio::time::interval(stale_node_timeout / 2);
 
     // Our main select loop atomically receives and handles telemetry messages from the node,
     // and periodically checks for stale connections to keep our ndoe state tidy.
@@ -348,7 +348,7 @@ where
                         continue;
                     }
 
-                    // Register the message ID against the network ID, and allow nodes with this message ID.
+                    // Note of the message ID, allowing telemetry for it.
                     allowed_message_ids.insert(message_id, Instant::now());
 
                     // Tell the aggregator loop about the new node.


### PR DESCRIPTION
This PR adds logic to tidy stale node connections. It will:

- Remove nodes when telemetry corresponding to the node message ID isn't seen for a while.
- Disconnect telemetry connections that haven't sent useful telemetry data in a while.

To accomodate this, I had to spawn our receiving of socket data onto a separate task, because it's not cancel-safe and so can't be interrupted by the periodic check that I wanted to do. (The alternative is using BiLocks and such and spawning out the periodic interval instead, but that was more cumbersome!)