### PR TITLE
Fix autosubscribe to subscribe to Polkadot instead of Kusama

### DIFF
--- a/frontend/src/Connection.ts
+++ b/frontend/src/Connection.ts
@@ -541,7 +541,7 @@ export class Connection {
     let topChain: Maybe<ChainData> = null;
 
     for (const chain of chains.values()) {
-      if (PINNED_CHAINS[chain.label] === 1) {
+      if (PINNED_CHAINS[chain.genesisHash] === 1) {
         topChain = chain;
         break;
       }


### PR DESCRIPTION
`PINNED_CHAINS` is mapping by genesis hash instead of label, so the lookups were always invalid and autosubscribe defaulted to top chain by number of nodes.