### PR TITLE
Jsdw no ci versions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@
 # stages:
 #   build:
 #     - Runs on commits on master or tags that match the pattern "v[0-9]+\.[0-9]+.*$". (e.g. 1.0, v2.1rc1)
-#   deploy-staging: 
+#   deploy-staging:
 #     - Runs on commits on master or tags that match the pattern v1.0, v2.1rc1 (continues deployment)
 #   deploy-production:
 #     - Runs on tags that match the pattern v1.0, v2.1rc1 (manual deployment)
@@ -11,12 +11,12 @@ variables:
   # Build Variables (Mandatory)
   CONTAINER_REPO:             ""
   DOCKERFILE_DIRECTORY:       ""
-  
+
   # Deploy Variables (Mandatory)
   HELM_NAMESPACE:             "substrate-telemetry"
   HELM_RELEASE_NAME:          "substrate-telemetry"
   HELM_CHART:                 "parity/substrate-telemetry"
-  
+
   # Deploy Variables (Optional)
   HELM_REPO_NAME:             "parity"
   HELM_REPO_URL:              "https://paritytech.github.io/helm-charts/"
@@ -26,8 +26,7 @@ variables:
   # Manual Variables (Optional)
   ## Could be used in the webconsole when triggering the pipeline manually
   ## DO NOT SET THEM IN THIS FILE!! They've been mentioned here only for documentation purposes!
-  FORCE_DEPLOY:               ""        # boolean: true or false - triggers the deploy-production stage
-  FORCE_DOCKER_TAG:           ""        # choose an existing docker tag to be deployed (e.g. v1.2.3)
+  FORCE_DOCKER_TAG:           ""        # choose an existing docker tag to be deployed (e.g. 224b1fae-beta)
 
   # Vault variables (Optional)
   VAULT_SERVER_URL:           "https://vault.parity-mgmt-vault.parity.io"
@@ -41,11 +40,8 @@ default:
       echo defining DOCKER_IMAGE_TAG variable
       if [[ $FORCE_DOCKER_TAG ]]; then
         export DOCKER_IMAGE_TAG="${FORCE_DOCKER_TAG}"
-      elif [[ $CI_COMMIT_TAG =~ ^v[0-9]+\.[0-9]+.*$ ]]; then
-        export DOCKER_IMAGE_TAG="${CI_COMMIT_TAG}"
-        export BUILD_LATEST_IMAGE="true"
       else
-        export DOCKER_IMAGE_TAG="${CI_COMMIT_SHORT_SHA}-beta"
+        export DOCKER_IMAGE_TAG="${CI_COMMIT_SHORT_SHA}"
       fi
 
 stages:
@@ -70,31 +66,19 @@ stages:
   script:
     - |-
       echo building "$CONTAINER_REPO:$DOCKER_IMAGE_TAG"
-      if [[ $BUILD_LATEST_IMAGE ]]; then
-        buildah bud \
+      buildah bud \
         --format=docker \
         --tag "$CONTAINER_REPO:$DOCKER_IMAGE_TAG" \
         --tag "$CONTAINER_REPO:latest" "$DOCKERFILE_DIRECTORY"
-      else
-        buildah bud \
-        --format=docker \
-        --tag "$CONTAINER_REPO:$DOCKER_IMAGE_TAG" "$DOCKERFILE_DIRECTORY"
-      fi
     - echo ${DOCKER_HUB_PASS} |
         buildah login --username ${DOCKER_HUB_USER} --password-stdin docker.io
     - |-
       echo pushing "$CONTAINER_REPO:$DOCKER_IMAGE_TAG"
-      if [[ $BUILD_LATEST_IMAGE ]]; then
-        buildah push --format=v2s2 "$CONTAINER_REPO:$DOCKER_IMAGE_TAG"
-        buildah push --format=v2s2 "$CONTAINER_REPO:latest"
-      else
-        buildah push --format=v2s2 "$CONTAINER_REPO:$DOCKER_IMAGE_TAG"
-      fi
+      buildah push --format=v2s2 "$CONTAINER_REPO:$DOCKER_IMAGE_TAG"
+      buildah push --format=v2s2 "$CONTAINER_REPO:latest"
   rules:
     - if: '$FORCE_DOCKER_TAG'
       when: never
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+.*$/'         # i.e. v1.0, v2.1rc1
-      when: always
     - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
       when: always
   tags:
@@ -160,7 +144,6 @@ deploy-staging:
   environment:
     name:                 parity-stg
   rules:
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+.*$/'       # i.e. v1.0, v2.1rc1
     - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
 
 deploy-production:
@@ -171,8 +154,4 @@ deploy-production:
   <<:                     *deploy
   environment:
     name:                 parity-prod
-  rules:
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+.*$/'       # i.e. v1.0, v2.1rc1
-      when: manual
-    - if: '$FORCE_DEPLOY == "true"'
-      when: manual
+  when: manual

--- a/README.md
+++ b/README.md
@@ -204,16 +204,3 @@ If something goes wrong running the above, we can roll back the deployment to li
 4. Add a variable called `FORCE_DOCKER_TAG` with a value corresponding to the tag you want to deploy, eg `224b1fae-beta`. Images must exist already for this tag.
 5. Hit 'Run Pipeline'. As above, a deployment to staging will be carried out, and if you're happy with that, you can hit the "play" button on the "Deploy-production" stage to perform the deployment to live.
 6. Confirm that things are working once the deployment has finished by visiting https://telemetry.polkadot.io/.
-
-### Deploying a commit that no image exists for
-
-This should be unnecessary, but I mention it here for the sake of completeness and to briefly mention the handling of specially tagged commits on master by the CI pipeline.
-
-If we want to deploy a commit that an image does not exist for (see https://hub.docker.com/r/parity/substrate-telemetry-backend/tags?page=1&ordering=last_updated), we can do the following.
-
-1. Tag the commit on `master` that you'd like to deploy, eg `git tag v0.1-foo`. The tag must be compatible with the regular expression `^v[0-9]+\.[0-9]+.*$`.
-2. Push the tag to master, eg `git push origin v0.1-foo`.
-3. This will kick off the deployment process, which in this case will also lead to new docker images being built. You can view the progress at https://gitlab.parity.io/parity/substrate-telemetry/-/pipelines.
-4. Once a deployment to staging has been successful, run whatever tests you need against the staging deployment to convince yourself that you're happy with it.
-5. Visit the CI/CD pipelines page again (URl above) and click the "play" button on the "Deploy-production" stage to perform the deployment to live.
-6. Confirm that things are working once the deployment has finished by visiting https://telemetry.polkadot.io/.

--- a/README.md
+++ b/README.md
@@ -190,17 +190,15 @@ Once we're happy with things in staging, we can do a deployment to live as follo
 
 1. Ensure that the PRs you'd like to deploy are merged to master.
 2. Navigate to https://gitlab.parity.io/parity/substrate-telemetry/-/pipelines/new.
-3. Add a variable called `FORCE_DEPLOY` with the value `true`.
-4. Hit 'Run Pipeline'. A deployment to staging will be carried out, and if you're happy with that, you can then hit the "play" button on the "Deploy-production" stage to perform the deployment to live.
-5. Confirm that things are working once the deployment has finished by visiting https://telemetry.polkadot.io/.
+3. Hit 'Run Pipeline'. A deployment to staging will be carried out, and if you're happy with that, you can then hit the "play" button on the "Deploy-production" stage to perform the deployment to live.
+4. Confirm that things are working once the deployment has finished by visiting https://telemetry.polkadot.io/.
 
 ### Rolling back to a previous deployment
 
 If something goes wrong running the above, we can roll back the deployment to live as follows.
 
-1. Decide what image tag you'd like to roll back to. Go to https://hub.docker.com/r/parity/substrate-telemetry-backend/tags?page=1&ordering=last_updated and have a look at the available tags (eg `224b1fae-beta`) to select one you'd like. You can cross reference this with the tags available using `git tag` in the repository to help see which tags correspond to which code changes.
+1. Decide what image tag you'd like to roll back to. Go to https://hub.docker.com/r/parity/substrate-telemetry-backend/tags?page=1&ordering=last_updated and have a look at the available image tags (eg `224b1fae-beta`) to select one you'd like. You can cross reference this with the commit hashes in `git log` to find a commit you want to revert to.
 2. Navigate to https://gitlab.parity.io/parity/substrate-telemetry/-/pipelines/new.
-3. Add a variable called `FORCE_DEPLOY` with the value `true`.
-4. Add a variable called `FORCE_DOCKER_TAG` with a value corresponding to the tag you want to deploy, eg `224b1fae-beta`. Images must exist already for this tag.
-5. Hit 'Run Pipeline'. As above, a deployment to staging will be carried out, and if you're happy with that, you can hit the "play" button on the "Deploy-production" stage to perform the deployment to live.
-6. Confirm that things are working once the deployment has finished by visiting https://telemetry.polkadot.io/.
+3. Add a variable called `FORCE_DOCKER_TAG` with a value corresponding to the tag you want to deploy, eg `224b1fae-beta`. Images must exist already for this tag.
+4. Hit 'Run Pipeline'. As above, a deployment to staging will be carried out, and if you're happy with that, you can hit the "play" button on the "Deploy-production" stage to perform the deployment to live.
+5. Confirm that things are working once the deployment has finished by visiting https://telemetry.polkadot.io/.


### PR DESCRIPTION
As a team we decided that it's easier not to think about version numbering when deploying.

I updated the README to reflect that in #414, but we could go one step further and simplify the CI file (and further simplify the README) if we have no interest in version numbering.

This makes releasing to live as simple as merging a PR to master and then, if we're happy with it in staging, going and pressing a "play" button in the CI to deploy it to live. We maintain the ability to roll back to previous images.