### PR TITLE
Timeout based on last msg received and not ping timeout

### DIFF
--- a/frontend/src/Connection.ts
+++ b/frontend/src/Connection.ts
@@ -601,11 +601,11 @@ function resettableTimeout(onExpired: () => void, timeoutMs: number) {
   let timer = setTimeout(onExpired, timeoutMs);
 
   return {
-    reset: () => {
+    reset() {
       clearTimeout(timer);
       timer = setTimeout(onExpired, timeoutMs);
     },
-    cancel: () => {
+    cancel() {
       clearTimeout(timer);
     },
   };

--- a/frontend/src/Connection.ts
+++ b/frontend/src/Connection.ts
@@ -597,7 +597,10 @@ export class Connection {
  * @param timeoutMs
  * @returns
  */
-function resettableTimeout(onExpired: () => void, timeoutMs: number) {
+function resettableTimeout(
+  onExpired: () => void,
+  timeoutMs: Types.Milliseconds
+) {
   let timer = setTimeout(onExpired, timeoutMs);
 
   return {


### PR DESCRIPTION
To help ease #417, this PR makes the UI timeout not be based on how long it takes to get a ping response, but on how long it takes to get back _any_ message from the backend (if messages are still being received, we assume that the connection is still active; it doesn't necesasrily have to be a ping response). I also allow 60 seconds from the last message seen, though we might feel that that is a bit high.

We still ping similarly to before to before in order to keep a connection alive if no other messages are being sent (eg UI not subscribed to anything), though since ping no longer determines success or fail, we only send the next ping out when the previous one returns.

Questions:
- Do we prefer to reconnect based on the ping timeout, to test that the entire round trip of the connection is OK and not just that we are still getting messages back OK (It feels like checking for msgs back is good enough to me)?
- Would we prefer an exponential reconnect? (This was my original plan, but it wasn't obvious in the current code how best to do it offhand; currently the disconnect-on-ping-timeout is sortof a by product of just trying to send another ping before the last one has come back, and we try to reconnect immediately on disconnect).