### PR TITLE
ci: increasing the helm upgrade timeout

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,7 +124,7 @@ stages:
     - helm upgrade
         --install
         --atomic
-        --timeout 120s
+        --timeout 600s
         --namespace $HELM_NAMESPACE
         --values custom-values.yaml
         --set image.backend.repository="${CONTAINER_REPO_BACKEND}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,7 +124,7 @@ stages:
     - helm upgrade
         --install
         --atomic
-        --timeout 600s
+        --timeout 300s
         --namespace $HELM_NAMESPACE
         --values custom-values.yaml
         --set image.backend.repository="${CONTAINER_REPO_BACKEND}"


### PR DESCRIPTION
Sometimes deploy to production job takes longer than 2minutes and the pipeline fails([sample](https://gitlab.parity.io/parity/substrate-telemetry/-/jobs/1151646)). This PR increases the timeout to 5 minutes.