### PR TITLE
Saturating subtract to avoid possible underflow

### DIFF
--- a/backend/telemetry_core/src/state/chain.rs
+++ b/backend/telemetry_core/src/state/chain.rs
@@ -259,7 +259,7 @@ impl Chain {
                     self.best.hash,
                 );
                 if let Some(timestamp) = self.timestamp {
-                    self.block_times.push(now - timestamp);
+                    self.block_times.push(now.saturating_sub(timestamp));
                     self.average_block_time = Some(self.block_times.average());
                 }
                 self.timestamp = Some(now);
@@ -271,7 +271,7 @@ impl Chain {
                 propagation_time = Some(0);
             } else if block.height == self.best.height {
                 if let Some(timestamp) = self.timestamp {
-                    propagation_time = Some(now - timestamp);
+                    propagation_time = Some(now.saturating_sub(timestamp));
                 }
             }
 


### PR DESCRIPTION
I left a telemetry instance running locally for a while and managed to run into:

```
thread 'telemetry_core_worker' panicked at 'attempt to subtract with overflow', telemetry_core/src/state/chain.rs:262:43
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Ie, when doing `now - timestamp`. I'm not exactly sure how this happened offhand, but as a quick fix to prevent against future issues I swapped to using `saturating_sub`.