### PR TITLE
First/Third party by genesis hash, not label. Make limit configurable and default to 1k

### DIFF
--- a/backend/telemetry_core/src/aggregator/aggregator.rs
+++ b/backend/telemetry_core/src/aggregator/aggregator.rs
@@ -41,6 +41,9 @@ pub struct AggregatorOpts {
     /// If our incoming message queue exceeds this length, we start
     /// dropping non-essential messages.
     pub max_queue_len: usize,
+    /// How many nodes from third party chains are allowed to connect
+    /// before we prevent connections from them.
+    pub max_third_party_nodes: usize,
 }
 
 struct AggregatorInternal {
@@ -75,6 +78,7 @@ impl Aggregator {
             tx_to_locator,
             opts.max_queue_len,
             opts.denylist,
+            opts.max_third_party_nodes,
         ));
 
         // Return a handle to our aggregator:
@@ -93,10 +97,16 @@ impl Aggregator {
         tx_to_aggregator: flume::Sender<(NodeId, Ipv4Addr)>,
         max_queue_len: usize,
         denylist: Vec<String>,
+        max_third_party_nodes: usize,
     ) {
-        inner_loop::InnerLoop::new(tx_to_aggregator, denylist, max_queue_len)
-            .handle(rx_from_external)
-            .await;
+        inner_loop::InnerLoop::new(
+            tx_to_aggregator,
+            denylist,
+            max_queue_len,
+            max_third_party_nodes,
+        )
+        .handle(rx_from_external)
+        .await;
     }
 
     /// Gather metrics from our aggregator loop

--- a/backend/telemetry_core/src/aggregator/inner_loop.rs
+++ b/backend/telemetry_core/src/aggregator/inner_loop.rs
@@ -195,9 +195,10 @@ impl InnerLoop {
         tx_to_locator: flume::Sender<(NodeId, Ipv4Addr)>,
         denylist: Vec<String>,
         max_queue_len: usize,
+        max_third_party_nodes: usize,
     ) -> Self {
         InnerLoop {
-            node_state: State::new(denylist),
+            node_state: State::new(denylist, max_third_party_nodes),
             node_ids: BiMap::new(),
             feed_channels: HashMap::new(),
             shard_channels: HashMap::new(),

--- a/backend/telemetry_core/src/main.rs
+++ b/backend/telemetry_core/src/main.rs
@@ -79,6 +79,9 @@ struct Opts {
     /// messages in an attempt to let it reduce?
     #[structopt(long)]
     aggregator_queue_len: Option<usize>,
+    /// How many nodes from third party chains are allowed to connect before we prevent connections from them.
+    #[structopt(long, default_value = "1000")]
+    max_third_party_nodes: usize,
 }
 
 fn main() {
@@ -128,6 +131,7 @@ async fn start_server(num_aggregators: usize, opts: Opts) -> anyhow::Result<()> 
         AggregatorOpts {
             max_queue_len: aggregator_queue_len,
             denylist: opts.denylist,
+            max_third_party_nodes: opts.max_third_party_nodes,
         },
     )
     .await?;

--- a/backend/telemetry_core/src/state/chain.rs
+++ b/backend/telemetry_core/src/state/chain.rs
@@ -20,6 +20,7 @@ use common::node_types::{BlockHash, BlockNumber};
 use common::{id_type, time, DenseMap, MostSeen, NumStats};
 use once_cell::sync::Lazy;
 use std::collections::HashSet;
+use std::str::FromStr;
 
 use crate::feed_message::{self, FeedMessageSerializer};
 use crate::find_location;
@@ -53,6 +54,9 @@ pub struct Chain {
     timestamp: Option<Timestamp>,
     /// Genesis hash of this chain
     genesis_hash: BlockHash,
+    /// Maximum number of third party nodes allowed. If the chain name ends up
+    /// corresponding to a third party network, t
+    max_nodes: usize,
 }
 
 pub enum AddNodeResult {
@@ -67,23 +71,31 @@ pub struct RemoveNodeResult {
     pub chain_renamed: bool,
 }
 
-/// Labels of chains we consider "first party". These chains allow any
+/// Genesis hashes of chains we consider "first party". These chains allow any
 /// number of nodes to connect.
-static FIRST_PARTY_NETWORKS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
-    let mut set = HashSet::new();
-    set.insert("Polkadot");
-    set.insert("Kusama");
-    set.insert("Westend");
-    set.insert("Rococo");
-    set
+static FIRST_PARTY_NETWORKS: Lazy<HashSet<BlockHash>> = Lazy::new(|| {
+    let genesis_hash_strs = &[
+        "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3", // Polkadot
+        "0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe", // Kusama
+        "0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e", // Westend
+        "0xf6e9983c37baf68846fedafe21e56718790e39fb1c582abc408b81bc7b208f9a", // Rococo
+    ];
+
+    genesis_hash_strs
+        .iter()
+        .map(|h| BlockHash::from_str(h).expect("hardcoded hash str should be valid"))
+        .collect()
 });
 
-/// Max number of nodes allowed to connect to the telemetry server.
-const THIRD_PARTY_NETWORKS_MAX_NODES: usize = 500;
+/// When we construct a chain, we want to check to see whether or not it's a "first party"
+/// network first, and assign a `max_nodes` accordingly. This helps us do that.
+pub fn is_first_party_network(genesis_hash: &BlockHash) -> bool {
+    FIRST_PARTY_NETWORKS.contains(genesis_hash)
+}
 
 impl Chain {
     /// Create a new chain with an initial label.
-    pub fn new(genesis_hash: BlockHash) -> Self {
+    pub fn new(genesis_hash: BlockHash, max_nodes: usize) -> Self {
         Chain {
             labels: MostSeen::default(),
             nodes: DenseMap::new(),
@@ -93,6 +105,7 @@ impl Chain {
             average_block_time: None,
             timestamp: None,
             genesis_hash,
+            max_nodes,
         }
     }
 
@@ -100,7 +113,7 @@ impl Chain {
     pub fn is_overquota(&self) -> bool {
         // Dynamically determine the max nodes based on the most common
         // label so far, in case it changes to something with a different limit.
-        self.nodes.len() >= max_nodes(self.labels.best())
+        self.nodes.len() >= self.max_nodes
     }
 
     /// Assign a node to this chain.
@@ -371,16 +384,5 @@ impl Chain {
     }
     pub fn genesis_hash(&self) -> BlockHash {
         self.genesis_hash
-    }
-}
-
-/// First party networks (Polkadot, Kusama etc) are allowed any number of nodes.
-/// Third party networks are allowed `THIRD_PARTY_NETWORKS_MAX_NODES` nodes and
-/// no more.
-fn max_nodes(label: &str) -> usize {
-    if FIRST_PARTY_NETWORKS.contains(label) {
-        usize::MAX
-    } else {
-        THIRD_PARTY_NETWORKS_MAX_NODES
     }
 }


### PR DESCRIPTION
Use genesis hash, not chain label, to determine how many nodes are allowed to be connected to a chain.
Set the limit to 1000, not 500, and make it configurable via the CLI.