### PR TITLE
move to rust 2021, tweak macro

### DIFF
--- a/backend/common/Cargo.toml
+++ b/backend/common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "common"
 version = "0.1.0"
 authors = ["Parity Technologies Ltd. <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 
 [dependencies]

--- a/backend/telemetry_core/Cargo.toml
+++ b/backend/telemetry_core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "telemetry_core"
 version = "0.1.0"
 authors = ["Parity Technologies Ltd. <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 
 [dependencies]

--- a/backend/telemetry_shard/Cargo.toml
+++ b/backend/telemetry_shard/Cargo.toml
@@ -2,7 +2,7 @@
 name = "telemetry_shard"
 version = "0.1.0"
 authors = ["Parity Technologies Ltd. <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0"
 
 [dependencies]

--- a/backend/test_utils/Cargo.toml
+++ b/backend/test_utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_utils"
 version = "0.1.0"
 authors = ["James Wilson <james@jsdw.me>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/backend/test_utils/src/contains_matches.rs
+++ b/backend/test_utils/src/contains_matches.rs
@@ -43,7 +43,7 @@ assert!(does_contain);
 */
 #[macro_export]
 macro_rules! contains_matches {
-    ($expression:expr, $( $( $pattern:pat )|+ $( if $guard:expr )? ),+ $(,)?) => {{
+    ($expression:expr, $( $( $pattern:pat_param )|+ $( if $guard:expr )? ),+ $(,)?) => {{
         let mut items = $expression.into_iter();
 
         // For each pattern we want to match, we consume items until
@@ -99,7 +99,7 @@ test_utils::assert_contains_matches!(
 */
 #[macro_export]
 macro_rules! assert_contains_matches {
-    ($expression:expr, $( $( $pattern:pat )|+ $( if $guard:expr )? ),+ $(,)?) => {
+    ($expression:expr, $( $( $pattern:pat_param )|+ $( if $guard:expr )? ),+ $(,)?) => {
         let does_contain_matches = $crate::contains_matches!(
             $expression,
             $( $( $pattern )|+ $( if $guard )? ),+

--- a/backend/test_utils/src/contains_matches.rs
+++ b/backend/test_utils/src/contains_matches.rs
@@ -43,7 +43,7 @@ assert!(does_contain);
 */
 #[macro_export]
 macro_rules! contains_matches {
-    ($expression:expr, $( $( $pattern:pat_param )|+ $( if $guard:expr )? ),+ $(,)?) => {{
+    ($expression:expr, $( $pattern:pat $( if $guard:expr )? ),+ $(,)?) => {{
         let mut items = $expression.into_iter();
 
         // For each pattern we want to match, we consume items until
@@ -63,7 +63,7 @@ macro_rules! contains_matches {
                 };
 
                 match item {
-                    $( $pattern )|+ $( if $guard )? => break,
+                    $pattern $( if $guard )? => break,
                     _ => continue
                 }
             }
@@ -99,10 +99,10 @@ test_utils::assert_contains_matches!(
 */
 #[macro_export]
 macro_rules! assert_contains_matches {
-    ($expression:expr, $( $( $pattern:pat_param )|+ $( if $guard:expr )? ),+ $(,)?) => {
+    ($expression:expr, $( $pattern:pat $( if $guard:expr )? ),+ $(,)?) => {
         let does_contain_matches = $crate::contains_matches!(
             $expression,
-            $( $( $pattern )|+ $( if $guard )? ),+
+            $( $pattern $( if $guard )? ),+
         );
 
         assert!(does_contain_matches);

--- a/backend/test_utils/src/contains_matches.rs
+++ b/backend/test_utils/src/contains_matches.rs
@@ -50,7 +50,7 @@ macro_rules! contains_matches {
         // we find the first match, and then break the loop and do the
         // same again with the next pattern. If we run out of items, we
         // set the validity to false and stop trying to match. Else, we
-        // match againse each of the patterns and return true.
+        // match against each of the patterns and return true.
         let mut is_valid = true;
         $(
             while is_valid {


### PR DESCRIPTION
Confirmed to build **and pass tests** locally on Ubuntu 20.04.3 LTS:
```
rustc 1.56.1 (59eed8a2a 2021-11-01)
rustc 1.58.0-nightly (e90c5fbbc 2021-11-12)
```

NOTE: the marco I tweaked without any context to fix this issue, please review :pray: 
```
Compiling test_utils v0.1.0 (/home/dan/git/telemetry/backend/test_utils)
error: `$pattern:pat` may be followed by `|`, which is not allowed for `pat` fragments
  --> test_utils/src/contains_matches.rs:46:44
   |
46 |     ($expression:expr, $( $( $pattern:pat )|+ $( if $guard:expr )? ),+ $(,)?) => {{
   |                                            ^ not allowed after `pat` fragments
   |
   = note: allowed there are: `=>`, `,`, `=`, `if` or `in`

error: `$pattern:pat` may be followed by `|`, which is not allowed for `pat` fragments
   --> test_utils/src/contains_matches.rs:102:44
    |
102 |     ($expression:expr, $( $( $pattern:pat )|+ $( if $guard:expr )? ),+ $(,)?) => {
    |                                            ^ not allowed after `pat` fragments
    |
    = note: allowed there are: `=>`, `,`, `=`, `if` or `in`

error: could not compile `test_utils` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: build failed
```