### PR TITLE
fix readme image names and remove network bit in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ If you'd like to get things running manually using Docker, you can do the follow
       --tmpfs /var/run:uid=101,gid=101 \
       --tmpfs /app/tmp:uid=101,gid=101 \
       --read-only \
-      substrate-telemetry-frontend
+      parity/substrate-telemetry-frontend
    ```
 
 With these running, you'll be able to navigate to [http://localhost:3000](http://localhost:3000) to view the UI. If you'd like to connect a node and have it send telemetry to your running shard, you can run the following:

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ If you'd like to get things running manually using Docker, you can do the follow
        --name backend-core \
        -p 8000:8000 \
        --read-only \
-       substrate-telemetry-backend \
+       parity/substrate-telemetry-backend \
        telemetry_core -l 0.0.0.0:8000
    ```
 
@@ -142,7 +142,7 @@ If you'd like to get things running manually using Docker, you can do the follow
        --name backend-shard \
        -p 8001:8001 \
        --read-only \
-       substrate-telemetry-backend \
+       parity/substrate-telemetry-backend \
        telemetry_shard -l 0.0.0.0:8001 -c http://backend-core:8000/shard_submit
    ```
 
@@ -152,15 +152,14 @@ If you'd like to get things running manually using Docker, you can do the follow
    docker run --rm -it --network=telemetry \
        --name frontend \
        -p 3000:8000 \
-       --read-only \
        -e SUBSTRATE_TELEMETRY_URL=ws://localhost:8000/feed \
-       substrate-telemetry-frontend
+       parity/substrate-telemetry-frontend
    ```
 
    **NOTE:** Here we used `SUBSTRATE_TELEMETRY_URL=ws://localhost:8000/feed`. This will work if you test with everything running locally on your machine but NOT if your backend runs on a remote server. Keep in mind that the frontend docker image is serving a static site running your browser. The `SUBSTRATE_TELEMETRY_URL` is the WebSocket url that your browser will use to reach the backend. Say your backend runs on a remote server at `foo.example.com`, you will need to set the IP/url accordingly in `SUBSTRATE_TELEMETRY_URL` (in this case, to `ws://foo.example.com/feed`).
 
    **NOTE:** Running the frontend container in *read-only* mode reduces attack surface that could be used to exploit
-   a container. It requires however a little more effort and mounting additionnal volumes as shown below:
+   a container. It requires however a little more effort and mounting additional volumes as shown below:
 
    ```
    docker run --rm -it -p 80:8000 --name frontend \
@@ -169,7 +168,7 @@ If you'd like to get things running manually using Docker, you can do the follow
       --tmpfs /var/run:uid=101,gid=101 \
       --tmpfs /app/tmp:uid=101,gid=101 \
       --read-only \
-      parity/substrate-telemetry-frontend
+      substrate-telemetry-frontend
    ```
 
 With these running, you'll be able to navigate to [http://localhost:3000](http://localhost:3000) to view the UI. If you'd like to connect a node and have it send telemetry to your running shard, you can run the following:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,5 @@
 version: "3"
 
-networks:
-  default:
-    # Give the default network created below a sensible name:
-    name: substrate-telemetry
-
 services:
   telemetry-frontend:
     build:


### PR DESCRIPTION
The image names were wrong, and the network section isn't really necessary AFAICT and may have caused an issue, so I removed it.

I tested these changes by running `docker-compose up` and trying to connect a node + browser, and similarly by manually running the docker commands in the README, and both worked fine for me.

closes #437 