### PR TITLE
Add manual deploy step with no restrictions.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,8 @@ default:
 
 stages:
   - build
-  - deploy-staging
+  - deploy-commit-to-staging
+  - deploy-master-to-staging
   - deploy-production
 
 
@@ -140,11 +141,23 @@ build-frontend:
     DOCKERFILE_DIRECTORY: "./frontend/"
   <<:                     *dockerize
 
-deploy-staging:
+# Manually build the docker images and deploy some commit to staging.
+deploy-commit-to-staging:
   variables:
     CONTAINER_REPO_BACKEND:  "docker.io/parity/substrate-telemetry-backend"
     CONTAINER_REPO_FRONTEND: "docker.io/parity/substrate-telemetry-frontend"
-  stage:                  deploy-staging
+  stage:                  deploy-commit-to-staging
+  <<:                     *deploy
+  environment:
+    name:                 parity-stg
+  when: manual
+
+# Autoamtically deploy `master` branch or tag like `v1.0` to staging
+deploy-master-to-staging:
+  variables:
+    CONTAINER_REPO_BACKEND:  "docker.io/parity/substrate-telemetry-backend"
+    CONTAINER_REPO_FRONTEND: "docker.io/parity/substrate-telemetry-frontend"
+  stage:                  deploy-master-to-staging
   <<:                     *deploy
   environment:
     name:                 parity-stg
@@ -152,6 +165,7 @@ deploy-staging:
     - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+.*$/'       # i.e. v1.0, v2.1rc1
     - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
 
+# Manually deploy a tag like `v1.0` to production
 deploy-production:
   variables:
     CONTAINER_REPO_BACKEND:  "docker.io/parity/substrate-telemetry-backend"


### PR DESCRIPTION
The purpose of this PR is to allow arbitrary commits to be manually deployed to staging with a button press, so that we can test external contributions and PRs on staging before we merge them to master.