### PR TITLE
support https and wss core url in shard's ws client

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -223,7 +223,9 @@ dependencies = [
  "soketto",
  "thiserror",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1340,6 +1342,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,6 +1375,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -1390,6 +1419,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -1554,6 +1593,12 @@ dependencies = [
  "rand",
  "sha-1",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spinning_top"
@@ -1829,6 +1874,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,6 +1985,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
@@ -2063,6 +2125,25 @@ checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/backend/common/Cargo.toml
+++ b/backend/common/Cargo.toml
@@ -29,6 +29,8 @@ thiserror = "1.0.24"
 tokio = { version = "1.8.2", features = ["full"] }
 tokio-util = { version = "0.6", features = ["compat"] }
 arrayvec = { version = "0.7.1", features = ["serde"] }
+tokio-rustls = "0.23.4"
+webpki-roots = "0.22.4"
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/backend/common/src/ws_client/connect.rs
+++ b/backend/common/src/ws_client/connect.rs
@@ -1,4 +1,3 @@
-use std::io;
 // Source code for the Substrate Telemetry Server.
 // Copyright (C) 2021 Parity Technologies (UK) Ltd.
 //
@@ -17,6 +16,7 @@ use std::io;
 use super::on_close::OnClose;
 use futures::{channel, StreamExt};
 use soketto::handshake::{Client, ServerResponse};
+use std::io;
 use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
@@ -246,8 +246,7 @@ pub async fn connect(uri: &http::Uri) -> Result<Connection, ConnectError> {
     let socket = TcpStream::connect((host, port)).await?;
     socket.set_nodelay(true).expect("socket set_nodelay failed");
     // wrap TCP stream with TLS if schema is https or wss
-    let socket =
-        may_connect_tls(socket, host.clone(), scheme == "https" || scheme == "wss").await?;
+    let socket = may_connect_tls(socket, host, scheme == "https" || scheme == "wss").await?;
 
     // Establish a WS connection:
     let mut client = Client::new(socket.compat(), host, &path);


### PR DESCRIPTION
I was trying to deploy telemetry to a cloud environment(azure container app), where all containers were deployed behind an API gateway. Only https endpoint were exposed. Then I found the shard's websocket client does not support tls connection. So I add one.