### PR TITLE
Remove unused AuthoritySet bits. Fix soak test warnings

### DIFF
--- a/backend/common/src/node_message.rs
+++ b/backend/common/src/node_message.rs
@@ -90,8 +90,6 @@ pub struct Finalized {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AfgAuthoritySet {
     pub authority_id: Box<str>,
-    pub authorities: Box<str>,
-    pub authority_set_id: Box<str>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -207,8 +205,6 @@ mod tests {
         bincode_can_serialize_and_deserialize(NodeMessage::V1 {
             payload: Payload::AfgAuthoritySet(AfgAuthoritySet {
                 authority_id: "foo".into(),
-                authorities: "foo".into(),
-                authority_set_id: "foo".into(),
             }),
         });
     }

--- a/backend/telemetry_core/tests/soak_tests.rs
+++ b/backend/telemetry_core/tests/soak_tests.rs
@@ -87,6 +87,7 @@ async fn run_soak_test(opts: SoakTestOpts) {
         },
         CoreOpts {
             worker_threads: opts.core_worker_threads,
+            num_aggregators: opts.core_num_aggregators,
             ..Default::default()
         },
         ShardOpts {
@@ -265,7 +266,7 @@ fn chain_names(total: usize) -> impl Iterator<Item = String> {
 /// General arguments that are used to start a soak test. Run `soak_test` as
 /// instructed by its documentation for full control over what is ran, or run
 /// preconfigured variants.
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt)]
 struct SoakTestOpts {
     /// The number of shards to run this test with
     #[structopt(long)]

--- a/backend/telemetry_shard/src/json_message/node_message.rs
+++ b/backend/telemetry_shard/src/json_message/node_message.rs
@@ -156,16 +156,12 @@ impl From<Finalized> for internal::Finalized {
 #[derive(Deserialize, Debug)]
 pub struct AfgAuthoritySet {
     pub authority_id: Box<str>,
-    pub authorities: Box<str>,
-    pub authority_set_id: Box<str>,
 }
 
 impl From<AfgAuthoritySet> for internal::AfgAuthoritySet {
     fn from(msg: AfgAuthoritySet) -> Self {
         internal::AfgAuthoritySet {
             authority_id: msg.authority_id,
-            authorities: msg.authorities,
-            authority_set_id: msg.authority_set_id,
         }
     }
 }


### PR DESCRIPTION
A couple of properties from the AuthoritySet were never actually used/passed to a node, so they have been removed to avoid confusion.

Also a wee tidy of soak tests to remove a warning.