### PR TITLE
Expose node's IP address via feed

### DIFF
--- a/backend/common/src/http_utils.rs
+++ b/backend/common/src/http_utils.rs
@@ -76,7 +76,7 @@ where
         );
     }
 
-    // Just a little ceremony we need to go to to return the correct response key:
+    // Just a little ceremony to return the correct response key:
     let mut accept_key_buf = [0; 32];
     let accept_key = generate_websocket_accept_key(key.as_bytes(), &mut accept_key_buf);
 

--- a/backend/common/src/node_message.rs
+++ b/backend/common/src/node_message.rs
@@ -159,6 +159,7 @@ mod tests {
                     network_id: ArrayString::new(),
                     startup_time: None,
                     sysinfo: None,
+                    ip: Some("127.0.0.1".into()),
                 },
             }),
         });

--- a/backend/common/src/node_message.rs
+++ b/backend/common/src/node_message.rs
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! This is the internal represenation of telemetry messages sent from nodes.
+//! This is the internal representation of telemetry messages sent from nodes.
 //! There is a separate JSON representation of these types, because internally we want to be
-//! able to serialize these messages to bincode, and various serde attribtues aren't compatible
+//! able to serialize these messages to bincode, and various serde attributes aren't compatible
 //! with this, hence this separate internal representation.
 
 use crate::node_types::{Block, BlockHash, BlockNumber, NodeDetails};

--- a/backend/common/src/node_types.rs
+++ b/backend/common/src/node_types.rs
@@ -42,6 +42,7 @@ pub struct NodeDetails {
     pub target_arch: Option<Box<str>>,
     pub target_env: Option<Box<str>>,
     pub sysinfo: Option<NodeSysInfo>,
+    pub ip: Option<Box<str>>,
 }
 
 /// Hardware and software information for the node.

--- a/backend/telemetry_core/src/aggregator/aggregator.rs
+++ b/backend/telemetry_core/src/aggregator/aggregator.rs
@@ -65,12 +65,13 @@ impl Aggregator {
         let (tx_to_aggregator, rx_from_external) = flume::unbounded();
 
         // Kick off a locator task to locate nodes, which hands back a channel to make location requests
-        let tx_to_locator =
-            find_location(tx_to_aggregator.clone().into_sink().with(|(node_id, msg)| {
+        let tx_to_locator = find_location(tx_to_aggregator.clone().into_sink().with(
+            |(node_id, ip, msg)| {
                 future::ok::<_, flume::SendError<_>>(inner_loop::ToAggregator::FromFindLocation(
-                    node_id, msg,
+                    node_id, ip, msg,
                 ))
-            }));
+            },
+        ));
 
         // Handle any incoming messages in our handler loop:
         tokio::spawn(Aggregator::handle_messages(

--- a/backend/telemetry_core/src/aggregator/aggregator.rs
+++ b/backend/telemetry_core/src/aggregator/aggregator.rs
@@ -44,7 +44,7 @@ pub struct AggregatorOpts {
     /// How many nodes from third party chains are allowed to connect
     /// before we prevent connections from them.
     pub max_third_party_nodes: usize,
-    /// Flag to expose the node's ip address to the feed subscribers.
+    /// Flag to expose the IP addresses of all connected nodes to the feed subscribers.
     pub expose_node_ips: bool,
 }
 

--- a/backend/telemetry_core/src/aggregator/inner_loop.rs
+++ b/backend/telemetry_core/src/aggregator/inner_loop.rs
@@ -174,7 +174,7 @@ pub struct InnerLoop {
     /// are prioritised and dropped to try and get back on track.
     max_queue_len: usize,
 
-    /// Flag to expose the node's ip address to the feed subscribers.
+    /// Flag to expose the IP addresses of all connected nodes to the feed subscribers.
     expose_node_ips: bool,
 }
 

--- a/backend/telemetry_core/src/aggregator/inner_loop.rs
+++ b/backend/telemetry_core/src/aggregator/inner_loop.rs
@@ -298,6 +298,7 @@ impl InnerLoop {
                 loc.latitude,
                 loc.longitude,
                 &loc.city,
+                None,
             ));
 
             let chain_genesis_hash = self

--- a/backend/telemetry_core/src/aggregator/inner_loop.rs
+++ b/backend/telemetry_core/src/aggregator/inner_loop.rs
@@ -144,7 +144,7 @@ impl FromStr for FromFeedWebsocket {
     }
 }
 
-/// The aggregator can these messages back to a feed connection.
+/// The aggregator can send these messages back to a feed connection.
 #[derive(Clone, Debug)]
 pub enum ToFeedWebsocket {
     Bytes(bytes::Bytes),
@@ -376,7 +376,7 @@ impl InnerLoop {
                         ));
                         self.finalize_and_broadcast_to_all_feeds(feed_messages_for_all);
 
-                        // Ask for the grographical location of the node.
+                        // Ask for the geographical location of the node.
                         let _ = self.tx_to_locator.send((node_id, ip));
                     }
                 }
@@ -548,7 +548,7 @@ impl InnerLoop {
                     let _ = feed_channel.send(ToFeedWebsocket::Bytes(bytes));
                 }
 
-                // Actually make a note of the new chain subsciption:
+                // Actually make a note of the new chain subscription:
                 let new_genesis_hash = new_chain.genesis_hash();
                 self.chain_to_feed_conn_ids
                     .insert(new_genesis_hash, feed_conn_id);

--- a/backend/telemetry_core/src/aggregator/inner_loop.rs
+++ b/backend/telemetry_core/src/aggregator/inner_loop.rs
@@ -37,7 +37,7 @@ use std::{net::IpAddr, str::FromStr};
 pub enum ToAggregator {
     FromShardWebsocket(ConnId, FromShardWebsocket),
     FromFeedWebsocket(ConnId, FromFeedWebsocket),
-    FromFindLocation(NodeId, IpAddr, find_location::Location),
+    FromFindLocation(NodeId, Option<IpAddr>, find_location::Location),
     /// Hand back some metrics. The provided sender is expected not to block when
     /// a message is sent into it.
     GatherMetrics(flume::Sender<Metrics>),
@@ -217,8 +217,8 @@ impl InnerLoop {
                     ToAggregator::FromShardWebsocket(shard_conn_id, msg) => {
                         self.handle_from_shard(shard_conn_id, msg)
                     }
-                    ToAggregator::FromFindLocation(node_id, ip, location) => {
-                        self.handle_from_find_location(node_id, ip, location)
+                    ToAggregator::FromFindLocation(node_id, maybe_ip, location) => {
+                        self.handle_from_find_location(node_id, maybe_ip, location)
                     }
                     ToAggregator::GatherMetrics(tx) => self.handle_gather_metrics(
                         tx,
@@ -290,7 +290,7 @@ impl InnerLoop {
     fn handle_from_find_location(
         &mut self,
         node_id: NodeId,
-        node_ip: IpAddr,
+        maybe_ip: Option<IpAddr>,
         location: find_location::Location,
     ) {
         self.node_state
@@ -303,7 +303,7 @@ impl InnerLoop {
                 loc.latitude,
                 loc.longitude,
                 &loc.city,
-                Some(&*node_ip.to_string()),
+                maybe_ip.map(|ip| ip.to_string()).as_deref(),
             ));
 
             let chain_genesis_hash = self

--- a/backend/telemetry_core/src/feed_message.rs
+++ b/backend/telemetry_core/src/feed_message.rs
@@ -189,6 +189,7 @@ impl FeedMessageWrite for AddedNode<'_> {
             &details.version,
             &details.validator,
             &details.network_id,
+            &details.ip,
         );
 
         ser.write(&(

--- a/backend/telemetry_core/src/feed_message.rs
+++ b/backend/telemetry_core/src/feed_message.rs
@@ -140,13 +140,7 @@ pub struct AddedNode<'a>(pub FeedNodeId, pub &'a Node);
 pub struct RemovedNode(pub FeedNodeId);
 
 #[derive(Serialize)]
-pub struct LocatedNode<'a>(
-    pub FeedNodeId,
-    pub f32,
-    pub f32,
-    pub &'a str,
-    pub Option<&'a str>,
-);
+pub struct LocatedNode<'a>(pub FeedNodeId, pub f32, pub f32, pub &'a str);
 
 #[derive(Serialize)]
 pub struct ImportedBlock<'a>(pub FeedNodeId, pub &'a BlockDetails);

--- a/backend/telemetry_core/src/feed_message.rs
+++ b/backend/telemetry_core/src/feed_message.rs
@@ -45,7 +45,7 @@ where
 }
 
 pub struct FeedMessageSerializer {
-    /// Current buffer,
+    /// Current buffer.
     buffer: Vec<u8>,
 }
 

--- a/backend/telemetry_core/src/feed_message.rs
+++ b/backend/telemetry_core/src/feed_message.rs
@@ -140,7 +140,13 @@ pub struct AddedNode<'a>(pub FeedNodeId, pub &'a Node);
 pub struct RemovedNode(pub FeedNodeId);
 
 #[derive(Serialize)]
-pub struct LocatedNode<'a>(pub FeedNodeId, pub f32, pub f32, pub &'a str);
+pub struct LocatedNode<'a>(
+    pub FeedNodeId,
+    pub f32,
+    pub f32,
+    pub &'a str,
+    pub Option<&'a str>,
+);
 
 #[derive(Serialize)]
 pub struct ImportedBlock<'a>(pub FeedNodeId, pub &'a BlockDetails);

--- a/backend/telemetry_core/src/find_location.rs
+++ b/backend/telemetry_core/src/find_location.rs
@@ -73,7 +73,7 @@ where
 }
 
 /// This struct can be used to make location requests, given
-/// an IPV4 address.
+/// an IPV4 or IPV6 address.
 #[derive(Debug, Clone)]
 struct Locator {
     city: Arc<maxminddb::Reader<&'static [u8]>>,

--- a/backend/telemetry_core/src/find_location.rs
+++ b/backend/telemetry_core/src/find_location.rs
@@ -31,7 +31,7 @@ pub type Location = Option<Arc<NodeLocation>>;
 /// to find a geographical location from this
 pub fn find_location<Id, R>(response_chan: R) -> flume::Sender<(Id, IpAddr)>
 where
-    R: Sink<(Id, Option<Arc<NodeLocation>>)> + Unpin + Send + Clone + 'static,
+    R: Sink<(Id, IpAddr, Option<Arc<NodeLocation>>)> + Unpin + Send + Clone + 'static,
     Id: Clone + Send + 'static,
 {
     let (tx, rx) = flume::unbounded();
@@ -63,7 +63,7 @@ where
                     let location = tokio::task::spawn_blocking(move || locator.locate(ip_address))
                         .await
                         .expect("Locate never panics");
-                    let _ = response_chan.send((id, location)).await;
+                    let _ = response_chan.send((id, ip_address, location)).await;
                 });
             }
         }

--- a/backend/telemetry_core/src/find_location.rs
+++ b/backend/telemetry_core/src/find_location.rs
@@ -31,7 +31,7 @@ pub type Location = Option<Arc<NodeLocation>>;
 /// to find a geographical location from this
 pub fn find_location<Id, R>(response_chan: R) -> flume::Sender<(Id, IpAddr)>
 where
-    R: Sink<(Id, IpAddr, Option<Arc<NodeLocation>>)> + Unpin + Send + Clone + 'static,
+    R: Sink<(Id, Option<Arc<NodeLocation>>)> + Unpin + Send + Clone + 'static,
     Id: Clone + Send + 'static,
 {
     let (tx, rx) = flume::unbounded();
@@ -63,7 +63,7 @@ where
                     let location = tokio::task::spawn_blocking(move || locator.locate(ip_address))
                         .await
                         .expect("Locate never panics");
-                    let _ = response_chan.send((id, ip_address, location)).await;
+                    let _ = response_chan.send((id, location)).await;
                 });
             }
         }

--- a/backend/telemetry_core/src/main.rs
+++ b/backend/telemetry_core/src/main.rs
@@ -82,6 +82,9 @@ struct Opts {
     /// How many nodes from third party chains are allowed to connect before we prevent connections from them.
     #[structopt(long, default_value = "1000")]
     max_third_party_nodes: usize,
+    /// Flag to expose the node's ip address to the feed subscribers.
+    #[structopt(long)]
+    expose_ip: bool,
 }
 
 fn main() {
@@ -132,6 +135,7 @@ async fn start_server(num_aggregators: usize, opts: Opts) -> anyhow::Result<()> 
             max_queue_len: aggregator_queue_len,
             denylist: opts.denylist,
             max_third_party_nodes: opts.max_third_party_nodes,
+            expose_ip: opts.expose_ip,
         },
     )
     .await?;

--- a/backend/telemetry_core/src/main.rs
+++ b/backend/telemetry_core/src/main.rs
@@ -82,7 +82,7 @@ struct Opts {
     /// How many nodes from third party chains are allowed to connect before we prevent connections from them.
     #[structopt(long, default_value = "1000")]
     max_third_party_nodes: usize,
-    /// Flag to expose the node's ip address to the feed subscribers.
+    /// Flag to expose the IP addresses of all connected nodes to the feed subscribers.
     #[structopt(long)]
     pub expose_node_ips: bool,
 }

--- a/backend/telemetry_core/src/main.rs
+++ b/backend/telemetry_core/src/main.rs
@@ -84,7 +84,7 @@ struct Opts {
     max_third_party_nodes: usize,
     /// Flag to expose the node's ip address to the feed subscribers.
     #[structopt(long)]
-    expose_ip: bool,
+    pub expose_node_ips: bool,
 }
 
 fn main() {
@@ -135,7 +135,7 @@ async fn start_server(num_aggregators: usize, opts: Opts) -> anyhow::Result<()> 
             max_queue_len: aggregator_queue_len,
             denylist: opts.denylist,
             max_third_party_nodes: opts.max_third_party_nodes,
-            expose_ip: opts.expose_ip,
+            expose_node_ips: opts.expose_node_ips,
         },
     )
     .await?;

--- a/backend/telemetry_core/src/state/state.rs
+++ b/backend/telemetry_core/src/state/state.rs
@@ -41,11 +41,11 @@ impl NodeId {
     }
 }
 
-/// Our state constains node and chain information
+/// Our state contains node and chain information
 pub struct State {
     chains: DenseMap<ChainId, Chain>,
 
-    // Find the right chain given various details.
+    /// Find the right chain given various details.
     chains_by_genesis_hash: HashMap<BlockHash, ChainId>,
 
     /// Chain labels that we do not want to allow connecting.
@@ -56,7 +56,7 @@ pub struct State {
     max_third_party_nodes: usize,
 }
 
-/// Adding a node to a chain leads to this node_idult
+/// Adding a node to a chain leads to this result.
 pub enum AddNodeResult<'a> {
     /// The chain is on the "deny list", so we can't add the node
     ChainOnDenyList,

--- a/backend/telemetry_core/src/state/state.rs
+++ b/backend/telemetry_core/src/state/state.rs
@@ -300,6 +300,7 @@ mod test {
             network_id: NetworkId::new(),
             startup_time: None,
             sysinfo: None,
+            ip: None,
         }
     }
 

--- a/backend/telemetry_shard/src/aggregator.rs
+++ b/backend/telemetry_shard/src/aggregator.rs
@@ -105,7 +105,7 @@ impl Aggregator {
     pub async fn spawn(telemetry_uri: http::Uri) -> anyhow::Result<Aggregator> {
         let (tx_to_aggregator, rx_from_external) = flume::bounded(10);
 
-        // Establish a resiliant connection to the core (this retries as needed):
+        // Establish a resilient connection to the core (this retries as needed):
         let (tx_to_telemetry_core, rx_from_telemetry_core) =
             create_ws_connection_to_core(telemetry_uri).await;
 

--- a/backend/telemetry_shard/src/json_message/node_message.rs
+++ b/backend/telemetry_shard/src/json_message/node_message.rs
@@ -248,6 +248,7 @@ pub struct NodeDetails {
     pub target_arch: Option<Box<str>>,
     pub target_env: Option<Box<str>>,
     pub sysinfo: Option<NodeSysInfo>,
+    pub ip: Option<Box<str>>,
 }
 
 impl From<NodeDetails> for node_types::NodeDetails {
@@ -280,6 +281,7 @@ impl From<NodeDetails> for node_types::NodeDetails {
             target_arch: details.target_arch,
             target_env: details.target_env,
             sysinfo: details.sysinfo.map(|sysinfo| sysinfo.into()),
+            ip: details.ip,
         }
     }
 }

--- a/backend/telemetry_shard/src/main.rs
+++ b/backend/telemetry_shard/src/main.rs
@@ -279,7 +279,7 @@ where
     let mut stale_interval = tokio::time::interval(stale_node_timeout / 2);
 
     // Our main select loop atomically receives and handles telemetry messages from the node,
-    // and periodically checks for stale connections to keep our ndoe state tidy.
+    // and periodically checks for stale connections to keep our node state tidy.
     loop {
         tokio::select! {
             // We periodically check for stale message IDs and remove nodes associated with

--- a/backend/test_utils/src/feed_message_de.rs
+++ b/backend/test_utils/src/feed_message_de.rs
@@ -134,6 +134,7 @@ pub struct NodeDetails {
     pub version: String,
     pub validator: Option<String>,
     pub network_id: Option<String>,
+    pub ip: Option<String>,
 }
 
 impl FeedMessage {
@@ -185,7 +186,7 @@ impl FeedMessage {
             3 => {
                 let (
                     node_id,
-                    (name, implementation, version, validator, network_id),
+                    (name, implementation, version, validator, network_id, ip),
                     stats,
                     io,
                     hardware,
@@ -205,6 +206,7 @@ impl FeedMessage {
                         version,
                         validator,
                         network_id,
+                        ip,
                     },
                     stats,
                     block_details,

--- a/backend/test_utils/src/feed_message_de.rs
+++ b/backend/test_utils/src/feed_message_de.rs
@@ -50,7 +50,6 @@ pub enum FeedMessage {
         lat: f32,
         long: f32,
         city: String,
-        ip: Option<String>,
     },
     ImportedBlock {
         node_id: usize,
@@ -220,13 +219,12 @@ impl FeedMessage {
             }
             // LocatedNode
             5 => {
-                let (node_id, lat, long, city, ip) = serde_json::from_str(raw_val.get())?;
+                let (node_id, lat, long, city) = serde_json::from_str(raw_val.get())?;
                 FeedMessage::LocatedNode {
                     node_id,
                     lat,
                     long,
                     city,
-                    ip,
                 }
             }
             // ImportedBlock

--- a/backend/test_utils/src/feed_message_de.rs
+++ b/backend/test_utils/src/feed_message_de.rs
@@ -50,6 +50,7 @@ pub enum FeedMessage {
         lat: f32,
         long: f32,
         city: String,
+        ip: Option<String>,
     },
     ImportedBlock {
         node_id: usize,
@@ -219,12 +220,13 @@ impl FeedMessage {
             }
             // LocatedNode
             5 => {
-                let (node_id, lat, long, city) = serde_json::from_str(raw_val.get())?;
+                let (node_id, lat, long, city, ip) = serde_json::from_str(raw_val.get())?;
                 FeedMessage::LocatedNode {
                     node_id,
                     lat,
                     long,
                     city,
+                    ip,
                 }
             }
             // ImportedBlock

--- a/frontend/src/common/types.ts
+++ b/frontend/src/common/types.ts
@@ -55,7 +55,8 @@ export type NodeDetails = [
   NodeImplementation,
   NodeVersion,
   Maybe<Address>,
-  Maybe<NetworkId>
+  Maybe<NetworkId>,
+  Maybe<string>
 ];
 export type NodeStats = [PeerCount, TransactionCount];
 export type NodeIO = [Array<Bytes>];


### PR DESCRIPTION
The location string was previously determined via qurying an external API.
After an upstream patch, telemetry now obtains the location string via an internal
database.

The location string is utilized by the 1kv program to generate scores for nodes.

It is possible, but not likely, that ranges of IP addresses cannot be determined from
the internal database.  An empty/wrong location can adversely impact the 1kv scoring.

This patch exposes a CLI flag for the telemetry-core to expose the IP address to
the connected feeds.

While at it, fix comment typos.

### Testing Done

* The following patch is applied to obtain the submitted bytes.
```patch
backend/telemetry_core/src/aggregator/inner_loop.rs

    fn finalize_and_broadcast_to_chain_feeds(
        &mut self,
        genesis_hash: &BlockHash,
        serializer: FeedMessageSerializer,
    ) {
        if let Some(bytes) = serializer.into_finalized() {
+             info!("bytes={:?} len={:?}", bytes, bytes.len());
            self.broadcast_to_chain_feeds(genesis_hash, ToFeedWebsocket::Bytes(bytes));
        }
    }
```

* Start the telemetry core with/without the `--expose-ip` flag. 
```bash
INFO  [telemetry_core::aggregator::inner_loop] bytes=b"[3,[0,[\"ludicrous-throat-6150\",\"Parity Polkadot\",\"0.9.25-43110299e44\",null,\"12D3KooWPWB6ydrx2nPBwwWm7mtocuv6ovPEik3HzgDWGGhATsnh\",\"127.0.0.1\"],[0,0],[[]],[[],[],[]],[0,\"0x0000000000000000000000000000000000000000000000000000000000000000\",0,1660658952013,null],null,1660658945889]]" len=279

INFO  [telemetry_core::aggregator::inner_loop] bytes=b"[3,[0,[\"combative-toys-9692\",\"Parity Polkadot\",\"0.9.25-43110299e44\",null,\"12D3KooWBLmuhjsyd79zEx9DQ5FtLdyrV7DBMiP5vjA8ABBamCtX\",null],[0,0],[[]],[[],[],[]],[0,\"0x0000000000000000000000000000000000000000000000000000000000000000\",0,1660659036020,null],null,1660659027142]]" len=270
```

Closes #490.