### PR TITLE
core: Fix noisy logs caused by closing the `/feed` browser

### DIFF
--- a/backend/telemetry_core/src/main.rs
+++ b/backend/telemetry_core/src/main.rs
@@ -464,23 +464,30 @@ where
                     .await
                 {
                     Err(_) => {
-                        log::warn!("Closing feed websocket that was too slow to keep up (too slow to send messages)");
+                        log::debug!("Closing feed websocket that was too slow to keep up (too slow to send messages)");
+                        break 'outer;
+                    }
+                    Ok(Err(soketto::connection::Error::Closed)) => {
                         break 'outer;
                     }
                     Ok(Err(e)) => {
-                        log::warn!("Closing feed websocket due to error sending data: {}", e);
+                        log::debug!("Closing feed websocket due to error sending data: {}", e);
                         break 'outer;
                     }
                     Ok(_) => {}
                 }
             }
+
             match tokio::time::timeout_at(message_send_deadline, ws_send.flush()).await {
                 Err(_) => {
-                    log::warn!("Closing feed websocket that was too slow to keep up (too slow to flush messages)");
+                    log::debug!("Closing feed websocket that was too slow to keep up (too slow to flush messages)");
+                    break;
+                }
+                Ok(Err(soketto::connection::Error::Closed)) => {
                     break;
                 }
                 Ok(Err(e)) => {
-                    log::warn!("Closing feed websocket due to error flushing data: {}", e);
+                    log::debug!("Closing feed websocket due to error flushing data: {}", e);
                     break;
                 }
                 Ok(_) => {}


### PR DESCRIPTION
Multiple warning messages originated from the `telemetry-core`' regarding flushing the WS connection.

```bash
WARN  [telemetry_core] Closing feed websocket due to error flushing data: connection closed
```

These errors can happen when the feed components (browsers) are closing the connection unexpectedly.
This behavior can be reproduced with the following patch, added between sending and flushing the data:

```diff
--- a/backend/telemetry_core/src/main.rs
+++ b/backend/telemetry_core/src/main.rs
@@ -474,6 +474,11 @@ where
                     Ok(_) => {}
                 }
             }
+
+            log::info!("Sent bytes, will flush the feed next. Close the browser now!");
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            log::info!("Finished sleeping");
+
             match tokio::time::timeout_at(message_send_deadline, ws_send.flush()).await {
```

To mitigate noisy logs, change the log level to debug for the cases of abruptly closing the socket.