### PR TITLE
Tweak logs and attempt to avoid races around removing nodes

### DIFF
--- a/backend/common/src/assign_id.rs
+++ b/backend/common/src/assign_id.rs
@@ -73,7 +73,10 @@ where
     }
 
     pub fn clear(&mut self) {
-        *self = AssignId::new();
+        // Leave the `current_id` as-is. Why? To avoid reusing IDs and risking
+        // race conditions where old messages can accidentally screw with new nodes
+        // that have been assigned the same ID.
+        self.mapping = BiMap::new();
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (Id, &Details)> {

--- a/backend/common/src/assign_id.rs
+++ b/backend/common/src/assign_id.rs
@@ -47,7 +47,9 @@ where
 
     pub fn assign_id(&mut self, details: Details) -> Id {
         let this_id = self.current_id;
-        self.current_id += 1;
+        // It's very unlikely we'll ever overflow the ID limit, but in case we do,
+        // a wrapping_add will almost certainly be fine:
+        self.current_id = self.current_id.wrapping_add(1);
         self.mapping.insert(this_id, details);
         this_id.into()
     }

--- a/backend/telemetry_core/src/aggregator/inner_loop.rs
+++ b/backend/telemetry_core/src/aggregator/inner_loop.rs
@@ -248,7 +248,7 @@ impl InnerLoop {
             }
 
             if let Err(e) = metered_tx.send(msg) {
-                log::error!("Cannot send message into aggregator: {}", e);
+                log::error!("Cannot send message into aggregator: {e}");
                 break;
             }
         }
@@ -386,10 +386,11 @@ impl InnerLoop {
                 let node_id = match self.node_ids.remove_by_right(&(shard_conn_id, local_id)) {
                     Some((node_id, _)) => node_id,
                     None => {
-                        log::error!(
-                            "Cannot find ID for node with shard/connectionId of {:?}/{:?}",
-                            shard_conn_id,
-                            local_id
+                        // It's possible that some race between removing and disconnecting shards might lead to
+                        // more than one remove message for the same node. This isn't really a problem, but we
+                        // hope it won't happen so make a note if it does:
+                        log::debug!(
+                            "Remove: Cannot find ID for node with shard/connectionId of {shard_conn_id:?}/{local_id:?}"
                         );
                         return;
                     }
@@ -401,9 +402,7 @@ impl InnerLoop {
                     Some(id) => *id,
                     None => {
                         log::error!(
-                            "Cannot find ID for node with shard/connectionId of {:?}/{:?}",
-                            shard_conn_id,
-                            local_id
+                            "Update: Cannot find ID for node with shard/connectionId of {shard_conn_id:?}/{local_id:?}"
                         );
                         return;
                     }
@@ -606,7 +605,7 @@ impl InnerLoop {
         let removed_details = match self.node_state.remove_node(node_id) {
             Some(remove_details) => remove_details,
             None => {
-                log::error!("Could not find node {:?}", node_id);
+                log::error!("Could not find node {node_id:?}");
                 return;
             }
         };

--- a/backend/telemetry_core/src/main.rs
+++ b/backend/telemetry_core/src/main.rs
@@ -251,10 +251,7 @@ where
                 break;
             }
             if let Err(e) = msg_info {
-                log::error!(
-                    "Shutting down websocket connection: Failed to receive data: {}",
-                    e
-                );
+                log::error!("Shutting down websocket connection: Failed to receive data: {e}");
                 break;
             }
 
@@ -262,10 +259,7 @@ where
                 match bincode::options().deserialize(&bytes) {
                     Ok(msg) => msg,
                     Err(e) => {
-                        log::error!(
-                            "Failed to deserialize message from shard; booting it: {}",
-                            e
-                        );
+                        log::error!("Failed to deserialize message from shard; booting it: {e}");
                         break;
                     }
                 };
@@ -292,7 +286,7 @@ where
             };
 
             if let Err(e) = tx_to_aggregator.send(aggregator_msg).await {
-                log::error!("Failed to send message to aggregator; closing shard: {}", e);
+                log::error!("Failed to send message to aggregator; closing shard: {e}");
                 break;
             }
         }
@@ -325,13 +319,10 @@ where
                 .expect("message to shard should serialize");
 
             if let Err(e) = ws_send.send_binary(bytes).await {
-                log::error!("Failed to send message to aggregator; closing shard: {}", e)
+                log::error!("Failed to send message to aggregator; closing shard: {e}")
             }
             if let Err(e) = ws_send.flush().await {
-                log::error!(
-                    "Failed to flush message to aggregator; closing shard: {}",
-                    e
-                )
+                log::error!("Failed to flush message to aggregator; closing shard: {e}")
             }
         }
 
@@ -374,7 +365,7 @@ where
         channel: tx_to_feed_conn,
     };
     if let Err(e) = tx_to_aggregator.send(init_msg).await {
-        log::error!("Error sending message to aggregator: {}", e);
+        log::error!("Error sending message to aggregator: {e}");
         return (tx_to_aggregator, ws_send);
     }
 
@@ -399,10 +390,7 @@ where
                 break;
             }
             if let Err(e) = msg_info {
-                log::error!(
-                    "Shutting down websocket connection: Failed to receive data: {}",
-                    e
-                );
+                log::error!("Shutting down websocket connection: Failed to receive data: {e}");
                 break;
             }
 
@@ -416,16 +404,12 @@ where
             let cmd = match FromFeedWebsocket::from_str(&text) {
                 Ok(cmd) => cmd,
                 Err(e) => {
-                    log::warn!(
-                        "Ignoring invalid command '{}' from the frontend: {}",
-                        text,
-                        e
-                    );
+                    log::warn!("Ignoring invalid command '{text}' from the frontend: {e}");
                     continue;
                 }
             };
             if let Err(e) = tx_to_aggregator.send(cmd).await {
-                log::error!("Failed to send message to aggregator; closing feed: {}", e);
+                log::error!("Failed to send message to aggregator; closing feed: {e}");
                 break;
             }
         }

--- a/backend/telemetry_shard/src/aggregator.rs
+++ b/backend/telemetry_shard/src/aggregator.rs
@@ -261,9 +261,14 @@ impl Aggregator {
                     // Remove references to this single node:
                     to_local_id.remove_by_id(local_id);
                     muted.remove(&local_id);
-                    let _ = tx_to_telemetry_core
-                        .send_async(FromShardAggregator::RemoveNode { local_id })
-                        .await;
+
+                    // If we're not connected to the core, don't buffer up remove messages. The core will remove
+                    // all nodes associated with this shard anyway, so the remove message would be redundant.
+                    if connected_to_telemetry_core {
+                        let _ = tx_to_telemetry_core
+                            .send_async(FromShardAggregator::RemoveNode { local_id })
+                            .await;
+                    }
                 }
                 ToAggregator::FromWebsocket(disconnected_conn_id, FromWebsocket::Disconnected) => {
                     // Find all of the local IDs corresponding to the disconnected connection ID and
@@ -280,9 +285,14 @@ impl Aggregator {
                     for local_id in local_ids_disconnected {
                         to_local_id.remove_by_id(local_id);
                         muted.remove(&local_id);
-                        let _ = tx_to_telemetry_core
-                            .send_async(FromShardAggregator::RemoveNode { local_id })
-                            .await;
+
+                        // If we're not connected to the core, don't buffer up remove messages. The core will remove
+                        // all nodes associated with this shard anyway, so the remove message would be redundant.
+                        if connected_to_telemetry_core {
+                            let _ = tx_to_telemetry_core
+                                .send_async(FromShardAggregator::RemoveNode { local_id })
+                                .await;
+                        }
                     }
                 }
                 ToAggregator::FromTelemetryCore(FromTelemetryCore::Mute {


### PR DESCRIPTION
- Updated some of the log messages to the nicer inline fmt style, and tweaked the odd message.
- Don't queue up "remove node" messages from shard to core if disconnected; they won't make sense after a reconnect.
- Try to avoid reusing IDs; this might cause races around disconnects if messages are queued or received with "old" IDs and new nodes are reusing said IDs.