### PR TITLE
CI exclude manual deploy-commit-to-staging from running on PR merge

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,7 +209,9 @@ deploy-commit-to-staging:
   <<:                     *deploy
   environment:
     name:                 parity-stg
-  when: manual
+  rules:
+    - if: '$CI_COMMIT_BRANCH =~ /^[0-9]+/'
+      when: manual
 
 # Automatically deploy `master` branch or tag like `v1.0` to staging
 deploy-master-to-staging:


### PR DESCRIPTION
Little fix to https://github.com/paritytech/substrate-telemetry/pull/557

Job `deploy-commit-to-staging` will not be added to pipeline which triggered by PR merge as it will fail because different org on hub.docker.com is used to store images.

@lexnv Let me know if it is necessary to deploy to staging when PR is merged, I can add separate job for this. 