### PR TITLE
Network Id Column: Show full Peer Id

### DIFF
--- a/frontend/src/components/List/Column/NetworkIdColumn.tsx
+++ b/frontend/src/components/List/Column/NetworkIdColumn.tsx
@@ -18,8 +18,7 @@ import * as React from 'react';
 import { Maybe } from '../../../common';
 import { ColumnProps } from './';
 import { Node } from '../../../state';
-import { Truncate } from '../../';
-import { Tooltip } from '../../';
+import { Tooltip, TooltipCopyCallback } from '../../';
 import icon from '../../../icons/fingerprint.svg';
 
 export class NetworkIdColumn extends React.Component<ColumnProps> {
@@ -30,6 +29,7 @@ export class NetworkIdColumn extends React.Component<ColumnProps> {
   public static readonly sortBy = ({ networkId }: Node) => networkId || '';
 
   private data: Maybe<string>;
+  private copy: Maybe<TooltipCopyCallback>;
 
   public shouldComponentUpdate(nextProps: ColumnProps) {
     return this.data !== nextProps.node.networkId;
@@ -45,10 +45,22 @@ export class NetworkIdColumn extends React.Component<ColumnProps> {
     }
 
     return (
-      <td className="Column">
-        <Tooltip text={networkId} position="left" />
-        <Truncate text={networkId} chars={10} />
+      <td className="Column" onClick={this.onClick}>
+        <Tooltip text={networkId} position="left" copy={this.onCopy} />
+        {networkId}
       </td>
     );
   }
+
+  private onCopy = (copy: TooltipCopyCallback) => {
+    this.copy = copy;
+  };
+
+  private onClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+
+    if (this.copy != null) {
+      this.copy();
+    }
+  };
 }


### PR DESCRIPTION
Fixes #571

This PR removes the truncation of the peer id column. this is less nice to look at but enables users to search for an id more easily using their browsers "search in page". I also added support for clicking the id to copy it to the clipboard.

![image](https://github.com/paritytech/substrate-telemetry/assets/62739623/3311d2af-75f8-4e65-8154-d59dd94bd56d)
