### PR TITLE
Feat: Map Node Stats (Version, Operating System etc) to each Node in Feed

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1723,6 +1723,7 @@ name = "telemetry_core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "bimap",
  "bincode",
  "bytes",

--- a/backend/common/src/node_types.rs
+++ b/backend/common/src/node_types.rs
@@ -38,7 +38,7 @@ pub struct NodeDetails {
     pub validator: Option<Box<str>>,
     pub network_id: NetworkId,
     pub startup_time: Option<Box<str>>,
-    pub target_os: Option<Box<str>>,
+    pub target_os: Option<Box<str>>,   //starts here
     pub target_arch: Option<Box<str>>,
     pub target_env: Option<Box<str>>,
     pub sysinfo: Option<NodeSysInfo>,

--- a/backend/telemetry_core/Cargo.toml
+++ b/backend/telemetry_core/Cargo.toml
@@ -21,6 +21,7 @@ maxminddb = "0.23.0"
 num_cpus = "1.13.0"
 once_cell = "1.8.0"
 parking_lot = "0.12.1"
+arrayvec = { version = "0.7.1", features = ["serde"] }
 primitive-types = { version = "0.12.1", features = ["serde"] }
 rayon = "1.5.1"
 reqwest = { version = "0.11.4", features = ["json"] }

--- a/backend/telemetry_core/src/aggregator/inner_loop.rs
+++ b/backend/telemetry_core/src/aggregator/inner_loop.rs
@@ -69,7 +69,7 @@ pub enum FromShardWebsocket {
     Disconnected,
 }
 
-/// The aggregator can these messages back to a shard connection.
+/// The aggregator can send these messages back to a shard connection.
 #[derive(Debug)]
 pub enum ToShardWebsocket {
     /// Mute messages to the core by passing the shard-local ID of them.
@@ -84,7 +84,7 @@ pub enum ToShardWebsocket {
 pub enum FromFeedWebsocket {
     /// When the socket is opened, it'll send this first
     /// so that we have a way to communicate back to it.
-    /// Unbounded so that slow feeds don't block aggregato
+    /// Unbounded so that slow feeds don't block aggregator
     /// progress.
     Initialize {
         channel: flume::Sender<ToFeedWebsocket>,

--- a/backend/telemetry_core/src/feed_message.rs
+++ b/backend/telemetry_core/src/feed_message.rs
@@ -186,13 +186,11 @@ impl FeedMessageWrite for AddedNode<'_> {
         let AddedNode(nid, node, expose_node_details) = self;
 
         let details = node.details();
-        // Hide the ip, sysinfo and hwbench if the `expose_node_details` flag was not specified.
+        // Always include sysinfo, conditionally include ip and hwbench based on expose_node_details.
         let node_hwbench = node.hwbench();
-        let (ip, sys_info, hwbench) = if *expose_node_details {
-            (&details.ip, &details.sysinfo, &node_hwbench)
-        } else {
-            (&None, &None, &None)
-        };
+        let ip = if *expose_node_details { &details.ip } else { &None };
+        let sys_info = &details.sysinfo;
+        let hwbench = if *expose_node_details { &node_hwbench } else { &None };
 
         let details = (
             &details.name,
@@ -200,6 +198,9 @@ impl FeedMessageWrite for AddedNode<'_> {
             &details.version,
             &details.validator,
             &details.network_id,
+            &details.target_os,
+            &details.target_arch,
+            &details.target_env,
             &ip,
             &sys_info,
             &hwbench,
@@ -217,6 +218,7 @@ impl FeedMessageWrite for AddedNode<'_> {
         ));
     }
 }
+
 
 #[derive(Serialize)]
 pub struct ChainStatsUpdate<'a>(pub &'a ChainStats);

--- a/backend/telemetry_core/src/feed_message.rs
+++ b/backend/telemetry_core/src/feed_message.rs
@@ -222,28 +222,30 @@ impl FeedMessageWrite for AddedNode<'_> {
 pub struct ChainStatsUpdate<'a>(pub &'a ChainStats);
 
 /// Ranking list out node details elements per node id and counts per elements
+/// `list`: List of node detail element per its count [( item, count )]
+/// `node_map`: A map 
 #[derive(Serialize, PartialEq, Eq, Default)]
-pub struct Ranking<K,NodeId: std::hash::Hash + Ord> {
+pub struct Ranking<K> {
     pub list: Vec<(K, u64)>,
     pub other: u64,
     pub unknown: u64,
-    pub node_map: HashMap<NodeId,K>
+    pub node_map: HashMap<ArrayString<64>,K>
 }
 
 #[derive(Serialize, PartialEq, Eq, Default)]
 pub struct ChainStats {
-    pub version: Ranking<String,ArrayString<64>>,
-    pub target_os: Ranking<String, ArrayString<64>>,
-    pub target_arch: Ranking<String,ArrayString<64>>,
-    pub cpu: Ranking<String, ArrayString<64>>,
-    pub memory: Ranking<(u32, Option<u32>),ArrayString<64>>,
-    pub core_count: Ranking<u32, ArrayString<64>>,
-    pub linux_kernel: Ranking<String,ArrayString<64>>,
-    pub linux_distro: Ranking<String,ArrayString<64>>,
-    pub is_virtual_machine: Ranking<bool,ArrayString<64>>,
-    pub cpu_hashrate_score: Ranking<(u32, Option<u32>),ArrayString<64>>,
-    pub memory_memcpy_score: Ranking<(u32, Option<u32>),ArrayString<64>>,
-    pub disk_sequential_write_score: Ranking<(u32, Option<u32>),ArrayString<64>>,
-    pub disk_random_write_score: Ranking<(u32, Option<u32>),ArrayString<64>>,
-    pub cpu_vendor: Ranking<String,ArrayString<64>>,
+    pub version: Ranking<String>,
+    pub target_os: Ranking<String>,
+    pub target_arch: Ranking<String>,
+    pub cpu: Ranking<String>,
+    pub memory: Ranking<(u32, Option<u32>)>,
+    pub core_count: Ranking<u32>,
+    pub linux_kernel: Ranking<String>,
+    pub linux_distro: Ranking<String>,
+    pub is_virtual_machine: Ranking<bool>,
+    pub cpu_hashrate_score: Ranking<(u32, Option<u32>)>,
+    pub memory_memcpy_score: Ranking<(u32, Option<u32>)>,
+    pub disk_sequential_write_score: Ranking<(u32, Option<u32>)>,
+    pub disk_random_write_score: Ranking<(u32, Option<u32>)>,
+    pub cpu_vendor: Ranking<String>,
 }

--- a/backend/telemetry_core/src/feed_message.rs
+++ b/backend/telemetry_core/src/feed_message.rs
@@ -17,6 +17,9 @@
 //! This module provides a way of encoding the various messages that we'll
 //! send to subscribed feeds (browsers).
 
+use std::collections::HashMap;
+
+use arrayvec::ArrayString;
 use serde::Serialize;
 
 use crate::state::Node;
@@ -218,27 +221,29 @@ impl FeedMessageWrite for AddedNode<'_> {
 #[derive(Serialize)]
 pub struct ChainStatsUpdate<'a>(pub &'a ChainStats);
 
+/// Ranking list out node details elements per node id and counts per elements
 #[derive(Serialize, PartialEq, Eq, Default)]
-pub struct Ranking<K> {
+pub struct Ranking<K,NodeId: std::hash::Hash + Ord> {
     pub list: Vec<(K, u64)>,
     pub other: u64,
     pub unknown: u64,
+    pub node_map: HashMap<NodeId,K>
 }
 
 #[derive(Serialize, PartialEq, Eq, Default)]
 pub struct ChainStats {
-    pub version: Ranking<String>,
-    pub target_os: Ranking<String>,
-    pub target_arch: Ranking<String>,
-    pub cpu: Ranking<String>,
-    pub memory: Ranking<(u32, Option<u32>)>,
-    pub core_count: Ranking<u32>,
-    pub linux_kernel: Ranking<String>,
-    pub linux_distro: Ranking<String>,
-    pub is_virtual_machine: Ranking<bool>,
-    pub cpu_hashrate_score: Ranking<(u32, Option<u32>)>,
-    pub memory_memcpy_score: Ranking<(u32, Option<u32>)>,
-    pub disk_sequential_write_score: Ranking<(u32, Option<u32>)>,
-    pub disk_random_write_score: Ranking<(u32, Option<u32>)>,
-    pub cpu_vendor: Ranking<String>,
+    pub version: Ranking<String,ArrayString<64>>,
+    pub target_os: Ranking<String, ArrayString<64>>,
+    pub target_arch: Ranking<String,ArrayString<64>>,
+    pub cpu: Ranking<String, ArrayString<64>>,
+    pub memory: Ranking<(u32, Option<u32>),ArrayString<64>>,
+    pub core_count: Ranking<u32, ArrayString<64>>,
+    pub linux_kernel: Ranking<String,ArrayString<64>>,
+    pub linux_distro: Ranking<String,ArrayString<64>>,
+    pub is_virtual_machine: Ranking<bool,ArrayString<64>>,
+    pub cpu_hashrate_score: Ranking<(u32, Option<u32>),ArrayString<64>>,
+    pub memory_memcpy_score: Ranking<(u32, Option<u32>),ArrayString<64>>,
+    pub disk_sequential_write_score: Ranking<(u32, Option<u32>),ArrayString<64>>,
+    pub disk_random_write_score: Ranking<(u32, Option<u32>),ArrayString<64>>,
+    pub cpu_vendor: Ranking<String,ArrayString<64>>,
 }

--- a/backend/telemetry_core/src/state/chain.rs
+++ b/backend/telemetry_core/src/state/chain.rs
@@ -227,9 +227,9 @@ impl Chain {
                     }
 
                     self.stats_collator
-                        .update_hwbench(old_hwbench.as_ref(), CounterValue::Decrement);
+                        .update_hwbench(node.details(),old_hwbench.as_ref(), CounterValue::Decrement);
                     self.stats_collator
-                        .update_hwbench(node.hwbench(), CounterValue::Increment);
+                        .update_hwbench(node.details(),node.hwbench(), CounterValue::Increment);
                 }
                 _ => {}
             }

--- a/backend/telemetry_core/src/state/chain_stats.rs
+++ b/backend/telemetry_core/src/state/chain_stats.rs
@@ -16,7 +16,7 @@
 
 use super::counter::{Counter, CounterValue};
 use crate::feed_message::ChainStats;
-use arrayvec::ArrayString;
+//use arrayvec::ArrayString;
 // These are the benchmark scores generated on our reference hardware.
 const REFERENCE_CPU_SCORE: u64 = 1028;
 const REFERENCE_MEMORY_SCORE: u64 = 14899;

--- a/backend/telemetry_core/src/state/chain_stats.rs
+++ b/backend/telemetry_core/src/state/chain_stats.rs
@@ -136,20 +136,20 @@ fn cpu_vendor(cpu: &Box<str>) -> &str {
 
 #[derive(Default)]
 pub struct ChainStatsCollator {
-    version: Counter<String,ArrayString<64>>,
-    target_os: Counter<String,ArrayString<64>>,
-    target_arch: Counter<String,ArrayString<64>>,
-    cpu: Counter<String,ArrayString<64>>,
-    memory: Counter<(u32, Option<u32>),ArrayString<64>>,
-    core_count: Counter<u32,ArrayString<64>>,
-    linux_kernel: Counter<String,ArrayString<64>>,
-    linux_distro: Counter<String,ArrayString<64>>,
-    is_virtual_machine: Counter<bool,ArrayString<64>>,
-    cpu_hashrate_score: Counter<(u32, Option<u32>),ArrayString<64>>,
-    memory_memcpy_score: Counter<(u32, Option<u32>),ArrayString<64>>,
-    disk_sequential_write_score: Counter<(u32, Option<u32>),ArrayString<64>>,
-    disk_random_write_score: Counter<(u32, Option<u32>),ArrayString<64>>,
-    cpu_vendor: Counter<String,ArrayString<64>>,
+    version: Counter<String>,
+    target_os: Counter<String>,
+    target_arch: Counter<String>,
+    cpu: Counter<String>,
+    memory: Counter<(u32, Option<u32>)>,
+    core_count: Counter<u32>,
+    linux_kernel: Counter<String>,
+    linux_distro: Counter<String>,
+    is_virtual_machine: Counter<bool>,
+    cpu_hashrate_score: Counter<(u32, Option<u32>),>,
+    memory_memcpy_score: Counter<(u32, Option<u32>)>,
+    disk_sequential_write_score: Counter<(u32, Option<u32>)>,
+    disk_random_write_score: Counter<(u32, Option<u32>)>,
+    cpu_vendor: Counter<String>,
 }
 
 impl ChainStatsCollator {

--- a/backend/telemetry_core/src/state/counter.rs
+++ b/backend/telemetry_core/src/state/counter.rs
@@ -17,7 +17,7 @@
 use arrayvec::ArrayString;
 
 use crate::feed_message::Ranking;
-use std::{collections::HashMap, str::FromStr};
+use std::{collections::HashMap, /*str::FromStr*/};
 
 
 /// A data structure which counts how many occurrences of a given key we've seen.

--- a/backend/telemetry_core/src/state/counter.rs
+++ b/backend/telemetry_core/src/state/counter.rs
@@ -15,11 +15,12 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::feed_message::Ranking;
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
+
 
 /// A data structure which counts how many occurrences of a given key we've seen.
 #[derive(Default)]
-pub struct Counter<K> {
+pub struct Counter<K, NodeId> {
     /// A map containing the number of occurrences of a given key.
     ///
     /// If there are none then the entry is removed.
@@ -27,6 +28,10 @@ pub struct Counter<K> {
 
     /// The number of occurrences where the key is `None`.
     empty: u64,
+
+    /// The map of Node Id ( Network Id) to the node detail element
+    /// i.e {"123DE": "aarch64"}
+    node_map: HashMap<NodeId,K>
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -35,12 +40,14 @@ pub enum CounterValue {
     Decrement,
 }
 
-impl<K> Counter<K>
+impl<K,NodeId> Counter<K,NodeId>
 where
     K: Sized + std::hash::Hash + Eq,
+    NodeId: std::hash::Hash + Eq + Clone + Copy + FromStr + AsRef<str> + Ord
+
 {
     /// Either adds or removes a single occurence of a given `key`.
-    pub fn modify<'a, Q>(&mut self, key: Option<&'a Q>, op: CounterValue)
+    pub fn modify<'a, Q>(&mut self,node_id: NodeId, key: Option<&'a Q>, op: CounterValue)
     where
         Q: ?Sized + std::hash::Hash + Eq,
         K: std::borrow::Borrow<Q>,
@@ -51,6 +58,8 @@ where
                 match op {
                     CounterValue::Increment => {
                         *entry += 1;
+                        // add the node Id and the value ( key ) to the node_map
+                        self.node_map.insert(node_id, key.to_owned());
                     }
                     CounterValue::Decrement => {
                         *entry -= 1;
@@ -58,13 +67,19 @@ where
                             // Don't keep entries for which there are no hits.
                             self.map.remove(key);
                         }
+                        // remove the node Id and the value ( key ) to the node_map
+                        self.node_map.remove(&node_id);
                     }
                 }
             } else {
                 assert_eq!(op, CounterValue::Increment);
                 self.map.insert(key.to_owned(), 1);
+                // add the node Id and the value ( key ) to the node_map
+                self.node_map.insert(node_id, key.to_owned()); 
             }
+            
         } else {
+            // The key is None, no need to update the map (nodeId -> key)
             match op {
                 CounterValue::Increment => {
                     self.empty += 1;
@@ -77,9 +92,10 @@ where
     }
 
     /// Generates a top-N table of the most common keys.
-    pub fn generate_ranking_top(&self, max_count: usize) -> Ranking<K>
+    pub fn generate_ranking_top(&self, max_count: usize) -> Ranking<K, NodeId>
     where
         K: Clone,
+        NodeId: Clone + std::hash::Hash + Ord
     {
         let mut all: Vec<(&K, u64)> = self.map.iter().map(|(key, count)| (key, *count)).collect();
         all.sort_unstable_by_key(|&(_, count)| !count);
@@ -99,13 +115,15 @@ where
             list,
             other,
             unknown: self.empty,
+            node_map: HashMap::new(),
         }
     }
 
     /// Generates a sorted table of all of the keys.
-    pub fn generate_ranking_ordered(&self) -> Ranking<K>
+    pub fn generate_ranking_ordered(&self) -> Ranking<K,NodeId>
     where
         K: Copy + Clone + Ord,
+        NodeId: Clone + std::hash::Hash + Ord
     {
         let mut list: Vec<(K, u64)> = self.map.iter().map(|(key, count)| (*key, *count)).collect();
         list.sort_unstable_by_key(|&(key, count)| (key, !count));
@@ -114,6 +132,7 @@ where
             list,
             other: 0,
             unknown: self.empty,
+            node_map: HashMap::new(),
         }
     }
 }

--- a/backend/telemetry_shard/src/json_message/mod.rs
+++ b/backend/telemetry_shard/src/json_message/mod.rs
@@ -19,5 +19,5 @@
 mod hash;
 mod node_message;
 
-pub use hash::Hash;
+//pub use hash::Hash;
 pub use node_message::*;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,6 +46,7 @@ export default class App extends React.Component {
   constructor(props: Record<string, unknown>) {
     super(props);
 
+    //todo! Check what's important to set to true, false
     this.settings = new PersistentObject(
       'settings',
       {
@@ -71,6 +72,20 @@ export default class App extends React.Component {
         blockpropagation: true,
         blocklasttime: false,
         uptime: false,
+        version: true, //starts here
+        target_os: true,
+        target_arch: true, 
+        core_count: true,
+        memory: true,
+        is_virtual_machine: true,
+        linux_distro: true,
+        linux_kernel: true,
+        cpu_hashrate_score: true,
+        memory_memcpy_score: true,
+        disk_sequential_write_score: true,
+        disk_random_write_score: true,
+        cpu_vendor: true,
+
       },
       (settings) => {
         const selectedColumns = this.selectedColumns(settings);

--- a/frontend/src/Connection.ts
+++ b/frontend/src/Connection.ts
@@ -150,6 +150,10 @@ export class Connection {
   }
 
   private handleMessages = (messages: FeedMessage.Message[]) => {
+    console.log("Messges \n");
+
+    console.log(messages);
+    
     this.messageTimeout?.reset();
     const { nodes, chains, sortBy, selectedColumns } = this.appState;
     const nodesStateRef = nodes.ref;
@@ -467,12 +471,15 @@ export class Connection {
   private handleFeedData = (event: MessageEvent) => {
     let data: FeedMessage.Data;
 
+    console.log("Am here on feedMessage  \n");
+    console.log(event.data as any as FeedMessage.Data);
+
     if (typeof event.data === 'string') {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       data = event.data as any as FeedMessage.Data;
     } else {
       const u8aData = new Uint8Array(event.data);
-
+      
       // Future-proofing for when we switch to binary feed
       if (u8aData[0] === 0x00) {
         return this.newVersion();
@@ -482,8 +489,9 @@ export class Connection {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       data = str as any as FeedMessage.Data;
+      
     }
-
+   
     this.handleMessages(FeedMessage.deserialize(data));
   };
 

--- a/frontend/src/Connection.ts
+++ b/frontend/src/Connection.ts
@@ -162,8 +162,6 @@ export class Connection {
     }
 
     for (const message of messages) {
-      console.log('message ACTIONS', message.action);
-      console.log('message', message.payload);
       switch (message.action) {
         case ACTIONS.FeedVersion: {
           if (message.payload !== VERSION) {
@@ -203,7 +201,6 @@ export class Connection {
             startupTime,
           ] = message.payload;
           const pinned = this.pins.has(nodeDetails[0]);
-          console.log('added node:', message.payload); //similar to action 3
           const node = new Node(
             pinned,
             id,
@@ -364,21 +361,6 @@ export class Connection {
         }
 
         case ACTIONS.ChainStatsUpdate: {
-          console.log('chain stats:', message.payload);
-          //const nodeId = message.payload.version.node_map;
-          const chainStats = message.payload as Record<string, any>; // This casts payload to a more flexible type
-
-          for (const [key, value] of Object.entries(chainStats)) {
-            // Check if value is not null or undefined and has a property 'node_map'
-            if (value && 'node_map' in value) {
-              const nodeMap = value.node_map;
-              console.log(`${key} node map:`, nodeMap);
-
-              // Use nodeMap here to update the details for each node
-              // ...
-            }
-          }
-
           this.appUpdate({ chainStats: message.payload });
           break;
         }

--- a/frontend/src/common/feed.ts
+++ b/frontend/src/common/feed.ts
@@ -98,7 +98,8 @@ interface AddedNodeMessage extends MessageBase {
     NodeHardware,
     BlockDetails,
     Maybe<NodeLocation>,
-    Maybe<Timestamp>
+    Maybe<Timestamp>,
+
   ];
 }
 

--- a/frontend/src/common/types.ts
+++ b/frontend/src/common/types.ts
@@ -25,6 +25,15 @@ export type NodeId = Id<'Node'>;
 export type NodeName = Opaque<string, 'NodeName'>;
 export type NodeImplementation = Opaque<string, 'NodeImplementation'>;
 export type NodeVersion = Opaque<string, 'NodeVersion'>;
+export type OperatingSystem = Opaque<string, 'OperatingSystem'>; //step 1
+export type CpuArchitecture = Opaque<string, 'CpuArchitecture'>; //step 1
+export type Cpu = number; //step 1
+export type CpuCores = number; //step 1
+export type TargetEnv = string; //step 1
+export type Memory = number; //step 1
+export type VirtualMachine = boolean; //step 1
+export type LinuxKernel = number; //step 1
+export type LinuxDistro = string; //step 1
 export type BlockNumber = Opaque<number, 'BlockNumber'>;
 export type BlockHash = Opaque<string, 'BlockHash'>;
 export type Address = Opaque<string, 'Address'>;
@@ -43,6 +52,17 @@ export type Bytes = Opaque<number, 'Bytes'>;
 export type BytesPerSecond = Opaque<number, 'BytesPerSecond'>;
 export type NetworkId = Opaque<string, 'NetworkId'>;
 
+
+
+export type NodeSysInfo = {
+  cpu: string | null;
+  memory: number | null;
+  core_count: number | null;
+  linux_kernel: string | null;
+  linux_distro: string | null;
+  is_virtual_machine: boolean | null;
+} | null;
+
 export type BlockDetails = [
   BlockNumber,
   BlockHash,
@@ -56,8 +76,56 @@ export type NodeDetails = [
   NodeVersion,
   Maybe<Address>,
   Maybe<NetworkId>,
-  Maybe<string>
+  OperatingSystem,
+  CpuArchitecture,
+  TargetEnv,
+  NodeSysInfo
 ];
+
+export type NodeSpecificDetail<T> = {
+  list: Array<[T, number]>;
+  node_map: Record<NodeId, T>;
+  other: number;
+  unknown: number;
+  
+};
+
+export type ExtraNodeDetails = {
+  version: NodeSpecificDetail<string>;
+  target_os: NodeSpecificDetail<string>;
+  target_arch: NodeSpecificDetail<string>;
+  cpu: NodeSpecificDetail<number>;
+  core_count: NodeSpecificDetail<number>;
+  memory: NodeSpecificDetail<string>; // or number, if memory is a number
+  is_virtual_machine: NodeSpecificDetail<boolean>;
+  linux_distro: NodeSpecificDetail<string>;
+  linux_kernel: NodeSpecificDetail<string>;
+  cpu_hashrate_score: NodeSpecificDetail<number>;
+  memory_memcpy_score: NodeSpecificDetail<number>;
+  disk_sequential_write_score: NodeSpecificDetail<number>;
+  disk_random_write_score: NodeSpecificDetail<number>;
+  cpu_vendor: NodeSpecificDetail<string>;
+};
+
+// export type NodeSpecificDetails = {
+//   version: string;
+//   target_os: string;
+//   target_arch: string;
+//   cpu: number;
+//   core_count: number;
+//   memory: string;
+//   is_virtual_machine: boolean;
+//   linux_distro: string;
+//   linux_kernel: string;
+//   cpu_hashrate_score: number;
+//   memory_memcpy_score: number;
+//   disk_sequential_write_score: number;
+//   disk_random_write_score: number;
+//   cpu_vendor: string;
+// };
+
+
+
 export type NodeStats = [PeerCount, TransactionCount];
 export type NodeIO = [Array<Bytes>];
 export type NodeHardware = [

--- a/frontend/src/common/types.ts
+++ b/frontend/src/common/types.ts
@@ -25,15 +25,15 @@ export type NodeId = Id<'Node'>;
 export type NodeName = Opaque<string, 'NodeName'>;
 export type NodeImplementation = Opaque<string, 'NodeImplementation'>;
 export type NodeVersion = Opaque<string, 'NodeVersion'>;
-export type OperatingSystem = Opaque<string, 'OperatingSystem'>; //step 1
-export type CpuArchitecture = Opaque<string, 'CpuArchitecture'>; //step 1
-export type Cpu = number; //step 1
-export type CpuCores = number; //step 1
-export type TargetEnv = string; //step 1
-export type Memory = number; //step 1
-export type VirtualMachine = boolean; //step 1
-export type LinuxKernel = number; //step 1
-export type LinuxDistro = string; //step 1
+export type OperatingSystem = Opaque<string, 'OperatingSystem'>; 
+export type CpuArchitecture = Opaque<string, 'CpuArchitecture'>; 
+export type Cpu = number; 
+export type CpuCores = number; 
+export type TargetEnv = string; 
+export type Memory = number; 
+export type VirtualMachine = boolean; 
+export type LinuxKernel = number; 
+export type LinuxDistro = string; 
 export type BlockNumber = Opaque<number, 'BlockNumber'>;
 export type BlockHash = Opaque<string, 'BlockHash'>;
 export type Address = Opaque<string, 'Address'>;
@@ -81,50 +81,6 @@ export type NodeDetails = [
   TargetEnv,
   NodeSysInfo
 ];
-
-export type NodeSpecificDetail<T> = {
-  list: Array<[T, number]>;
-  node_map: Record<NodeId, T>;
-  other: number;
-  unknown: number;
-  
-};
-
-export type ExtraNodeDetails = {
-  version: NodeSpecificDetail<string>;
-  target_os: NodeSpecificDetail<string>;
-  target_arch: NodeSpecificDetail<string>;
-  cpu: NodeSpecificDetail<number>;
-  core_count: NodeSpecificDetail<number>;
-  memory: NodeSpecificDetail<string>; // or number, if memory is a number
-  is_virtual_machine: NodeSpecificDetail<boolean>;
-  linux_distro: NodeSpecificDetail<string>;
-  linux_kernel: NodeSpecificDetail<string>;
-  cpu_hashrate_score: NodeSpecificDetail<number>;
-  memory_memcpy_score: NodeSpecificDetail<number>;
-  disk_sequential_write_score: NodeSpecificDetail<number>;
-  disk_random_write_score: NodeSpecificDetail<number>;
-  cpu_vendor: NodeSpecificDetail<string>;
-};
-
-// export type NodeSpecificDetails = {
-//   version: string;
-//   target_os: string;
-//   target_arch: string;
-//   cpu: number;
-//   core_count: number;
-//   memory: string;
-//   is_virtual_machine: boolean;
-//   linux_distro: string;
-//   linux_kernel: string;
-//   cpu_hashrate_score: number;
-//   memory_memcpy_score: number;
-//   disk_sequential_write_score: number;
-//   disk_random_write_score: number;
-//   cpu_vendor: string;
-// };
-
-
 
 export type NodeStats = [PeerCount, TransactionCount];
 export type NodeIO = [Array<Bytes>];

--- a/frontend/src/components/List/Column/Column.tsx
+++ b/frontend/src/components/List/Column/Column.tsx
@@ -38,7 +38,7 @@ import {
   BlockPropagationColumn,
   LastBlockColumn,
   UptimeColumn,
-  CpuArchitectureColumn,
+  CpuArchitectureColumn, //extra columns added 
   CpuColumn,
   CpuCoresColumn,
   LinuxKernelColumn,

--- a/frontend/src/components/List/Column/Column.tsx
+++ b/frontend/src/components/List/Column/Column.tsx
@@ -38,6 +38,15 @@ import {
   BlockPropagationColumn,
   LastBlockColumn,
   UptimeColumn,
+  CpuArchitectureColumn,
+  CpuColumn,
+  CpuCoresColumn,
+  LinuxKernelColumn,
+  IsVirtualMachineColumn,
+  MemoryColumn,
+  OperatingSystemColumn,
+  VersionColumn,
+  LinuxDistroColumn,
 } from './';
 
 export type Column =
@@ -58,7 +67,16 @@ export type Column =
   | typeof BlockTimeColumn
   | typeof BlockPropagationColumn
   | typeof LastBlockColumn
-  | typeof UptimeColumn;
+  | typeof UptimeColumn
+  | typeof CpuArchitectureColumn
+  | typeof CpuColumn
+  | typeof CpuCoresColumn
+  | typeof LinuxDistroColumn
+  | typeof LinuxKernelColumn
+  | typeof IsVirtualMachineColumn
+  | typeof MemoryColumn
+  | typeof OperatingSystemColumn
+  | typeof VersionColumn;
 
 export interface ColumnProps {
   node: Node;

--- a/frontend/src/components/List/Column/CpuArchitectureColumn.tsx
+++ b/frontend/src/components/List/Column/CpuArchitectureColumn.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { ColumnProps } from './';
+import { Node } from '../../../state';
+import icon from '../../../icons/file-binary.svg';
+
+export class CpuArchitectureColumn extends React.Component<ColumnProps> {
+    public static readonly label = 'CPU Architecture';
+    public static readonly icon = icon;
+    public static readonly width = 154;
+    public static readonly setting = 'target_arch';
+    public static readonly sortBy = ({ target_arch }: Node) => target_arch || '';
+  
+    private data: string;
+    
+  
+    public shouldComponentUpdate(nextProps: ColumnProps) {
+      return this.data !== nextProps.node.hash;
+    }
+  
+    render() {
+      const { target_arch } = this.props.node;
+  
+      this.data = target_arch;
+  
+      return (
+        <td className="Column">
+          {target_arch} 
+        </td>
+      );
+    }
+  }
+
+  

--- a/frontend/src/components/List/Column/CpuArchitectureColumn.tsx
+++ b/frontend/src/components/List/Column/CpuArchitectureColumn.tsx
@@ -1,3 +1,20 @@
+// Source code for the Substrate Telemetry Server.
+// Copyright (C) 2023 Parity Technologies (UK) Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//Column for specifying which CPU Architecture the node is running on
 import * as React from 'react';
 import { ColumnProps } from './';
 import { Node } from '../../../state';

--- a/frontend/src/components/List/Column/CpuColumn.tsx
+++ b/frontend/src/components/List/Column/CpuColumn.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { ColumnProps } from './';
+import { Node } from '../../../state';
+import icon from '../../../icons/file-binary.svg';
+
+export class CpuColumn extends React.Component<ColumnProps> {
+    public static readonly label = 'CPU Column';
+    public static readonly icon = icon;
+    public static readonly width = 154;
+    public static readonly setting = 'cpu';
+    public static readonly sortBy = ({ cpu }: Node) => cpu || 0;
+  
+    private data: number;
+  
+    public shouldComponentUpdate(nextProps: ColumnProps) {
+      return this.data !== nextProps.node.cpu;
+    }
+
+    render() {
+      const { cpu } = this.props.node;
+  
+      this.data = cpu;
+
+      return (
+        <td className="Column">
+          {cpu}
+        </td>
+      ); 
+      
+    }
+  
+    
+  }
+  

--- a/frontend/src/components/List/Column/CpuColumn.tsx
+++ b/frontend/src/components/List/Column/CpuColumn.tsx
@@ -1,3 +1,21 @@
+// Source code for the Substrate Telemetry Server.
+// Copyright (C) 2023 Parity Technologies (UK) Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//Column for specifying which CPU type the node is running on
+
 import * as React from 'react';
 import { ColumnProps } from './';
 import { Node } from '../../../state';

--- a/frontend/src/components/List/Column/CpuCoresColumn.tsx
+++ b/frontend/src/components/List/Column/CpuCoresColumn.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { ColumnProps } from './';
+import { Node } from '../../../state';
+import icon from '../../../icons/file-binary.svg';
+
+export class CpuCoresColumn extends React.Component<ColumnProps> {
+    public static readonly label = 'CPU Cores';
+    public static readonly icon = icon;
+    public static readonly width = 154;
+    public static readonly setting = 'core_count';
+    public static readonly sortBy = ({ core_count }: Node) => core_count || 0;
+  
+    private data: number;
+  
+    public shouldComponentUpdate(nextProps: ColumnProps) {
+      return this.data !== nextProps.node.core_count;
+    }
+  
+    render() {
+      const { core_count } = this.props.node;
+  
+      this.data = core_count;
+  
+      return (
+        <td className="Column">
+          {core_count}
+        </td>
+      );
+    }
+  }
+  

--- a/frontend/src/components/List/Column/CpuCoresColumn.tsx
+++ b/frontend/src/components/List/Column/CpuCoresColumn.tsx
@@ -1,3 +1,18 @@
+// Source code for the Substrate Telemetry Server.
+// Copyright (C) 2023 Parity Technologies (UK) Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 import * as React from 'react';
 import { ColumnProps } from './';
 import { Node } from '../../../state';

--- a/frontend/src/components/List/Column/IsVirtualMachineColumn.tsx
+++ b/frontend/src/components/List/Column/IsVirtualMachineColumn.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { ColumnProps } from './';
+import { Node } from '../../../state';
+import icon from '../../../icons/file-binary.svg';
+
+export class IsVirtualMachineColumn extends React.Component<ColumnProps> {
+    public static readonly label = 'Virtual Machine';
+    public static readonly icon = icon;
+    public static readonly width = 154;
+    public static readonly setting = 'is_virtual_machine';
+    public static readonly sortBy = ({ is_virtual_machine }: Node) => is_virtual_machine || false;
+  
+    private data: boolean;
+
+  
+    public shouldComponentUpdate(nextProps: ColumnProps) {
+      return this.data !== nextProps.node.is_virtual_machine;
+    }
+  
+    render() {
+      const { is_virtual_machine } = this.props.node;
+  
+      this.data = is_virtual_machine;
+  
+      return (
+        <td className="Column">
+          {is_virtual_machine}
+        </td>
+      );
+    }
+  }

--- a/frontend/src/components/List/Column/IsVirtualMachineColumn.tsx
+++ b/frontend/src/components/List/Column/IsVirtualMachineColumn.tsx
@@ -1,3 +1,20 @@
+// Source code for the Substrate Telemetry Server.
+// Copyright (C) 2023 Parity Technologies (UK) Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//Column for specifying whether each node runs a VM or not
 import * as React from 'react';
 import { ColumnProps } from './';
 import { Node } from '../../../state';

--- a/frontend/src/components/List/Column/LinuxDistroColumn.tsx
+++ b/frontend/src/components/List/Column/LinuxDistroColumn.tsx
@@ -1,3 +1,22 @@
+// Source code for the Substrate Telemetry Server.
+// Copyright (C) 2023 Parity Technologies (UK) Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//Column for specifying type of distro each node is running (Linux Distribution)
+
+
 import * as React from 'react';
 import { ColumnProps } from './';
 import { Node } from '../../../state';

--- a/frontend/src/components/List/Column/LinuxDistroColumn.tsx
+++ b/frontend/src/components/List/Column/LinuxDistroColumn.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { ColumnProps } from './';
+import { Node } from '../../../state';
+import icon from '../../../icons/file-binary.svg';
+
+export class LinuxDistroColumn extends React.Component<ColumnProps> {
+    public static readonly label = 'Linux Distro';
+    public static readonly icon = icon;
+    public static readonly width = 154;
+    public static readonly setting = 'linux_distro';
+    public static readonly sortBy = ({ linux_distro }: Node) => linux_distro || '';
+  
+    private data: string;
+  
+    public shouldComponentUpdate(nextProps: ColumnProps) {
+      return this.data !== nextProps.node.linux_distro;
+    }
+  
+    render() {
+      const { linux_distro } = this.props.node;
+  
+      this.data = linux_distro;
+  
+      return (
+        <td className="Column">
+          {linux_distro}
+        </td>
+      );
+    }
+  }

--- a/frontend/src/components/List/Column/LinuxKernelColumn.tsx
+++ b/frontend/src/components/List/Column/LinuxKernelColumn.tsx
@@ -1,3 +1,20 @@
+// Source code for the Substrate Telemetry Server.
+// Copyright (C) 2023 Parity Technologies (UK) Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//Column for specifying which kernel each node is running on
 import * as React from 'react';
 import { ColumnProps } from './';
 import { Node } from '../../../state';

--- a/frontend/src/components/List/Column/LinuxKernelColumn.tsx
+++ b/frontend/src/components/List/Column/LinuxKernelColumn.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { ColumnProps } from './';
+import { Node } from '../../../state';
+import icon from '../../../icons/file-binary.svg';
+
+export class LinuxKernelColumn extends React.Component<ColumnProps> {
+    public static readonly label = 'Linux Kernel';
+    public static readonly icon = icon;
+    public static readonly width = 154;
+    public static readonly setting = 'linux_kernel';
+    public static readonly sortBy = ({ linux_kernel }: Node) => linux_kernel || 0;
+  
+    private data: number;
+  
+    public shouldComponentUpdate(nextProps: ColumnProps) {
+      return this.data !== nextProps.node.linux_kernel;
+    }
+  
+    render() {
+      const { linux_kernel } = this.props.node;
+  
+      this.data = linux_kernel;
+  
+      return (
+        <td className="Column">
+          {linux_kernel}
+        </td>
+      );
+    }
+  }

--- a/frontend/src/components/List/Column/MemoryColumn.tsx
+++ b/frontend/src/components/List/Column/MemoryColumn.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { ColumnProps } from './';
+import { Node } from '../../../state';
+import icon from '../../../icons/file-binary.svg';
+
+export class MemoryColumn extends React.Component<ColumnProps> {
+    public static readonly label = 'memory';
+    public static readonly icon = icon;
+    public static readonly width = 154;
+    public static readonly setting = 'memory';
+    public static readonly sortBy = ({ memory }: Node) => memory|| '';
+  
+    private data: number;
+
+  
+    public shouldComponentUpdate(nextProps: ColumnProps) {
+      return this.data !== nextProps.node.memory;
+    }
+  
+    render() {
+      const { memory} = this.props.node;
+  
+      this.data = memory;
+  
+      return (
+        <td className="Column">
+          {memory} 
+        </td>
+      );
+    }
+  }

--- a/frontend/src/components/List/Column/MemoryColumn.tsx
+++ b/frontend/src/components/List/Column/MemoryColumn.tsx
@@ -1,3 +1,20 @@
+// Source code for the Substrate Telemetry Server.
+// Copyright (C) 2023 Parity Technologies (UK) Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//Column specifying type of memory each node has
 import * as React from 'react';
 import { ColumnProps } from './';
 import { Node } from '../../../state';

--- a/frontend/src/components/List/Column/OperatingSystemColumn.tsx
+++ b/frontend/src/components/List/Column/OperatingSystemColumn.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { ColumnProps } from './';
+import { Node } from '../../../state';
+import icon from '../../../icons/file-binary.svg';
+
+export class OperatingSystemColumn extends React.Component<ColumnProps> {
+    public static readonly label = 'OS';
+    public static readonly icon = icon;
+    public static readonly width = 154;
+    public static readonly setting = 'target_os';
+    public static readonly sortBy = ({ target_os }: Node) => target_os || '';
+  
+    private data: string;
+    
+  
+    public shouldComponentUpdate(nextProps: ColumnProps) {
+      return this.data !== nextProps.node.hash;
+    }
+  
+    render() {
+      const { target_os } = this.props.node;
+  
+      this.data = target_os;
+  
+      return (
+        <td className="Column">
+          {target_os} 
+        </td>
+      );
+    }
+  }

--- a/frontend/src/components/List/Column/OperatingSystemColumn.tsx
+++ b/frontend/src/components/List/Column/OperatingSystemColumn.tsx
@@ -1,3 +1,21 @@
+// Source code for the Substrate Telemetry Server.
+// Copyright (C) 2023 Parity Technologies (UK) Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//Column for specifying which OS the node is running on
+
 import * as React from 'react';
 import { ColumnProps } from './';
 import { Node } from '../../../state';

--- a/frontend/src/components/List/Column/VersionColumn.tsx
+++ b/frontend/src/components/List/Column/VersionColumn.tsx
@@ -1,3 +1,21 @@
+// Source code for the Substrate Telemetry Server.
+// Copyright (C) 2023 Parity Technologies (UK) Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//Column for specifying which polkadot version node is running on
+
 import * as React from 'react';
 import { ColumnProps } from './';
 import { Node } from '../../../state';

--- a/frontend/src/components/List/Column/VersionColumn.tsx
+++ b/frontend/src/components/List/Column/VersionColumn.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { ColumnProps } from './';
+import { Node } from '../../../state';
+import icon from '../../../icons/file-binary.svg';
+
+export class VersionColumn extends React.Component<ColumnProps> {
+    public static readonly label = 'version';
+    public static readonly icon = icon;
+    public static readonly width = 154;
+    public static readonly setting = 'version';
+    public static readonly sortBy = ({ version}: Node) => version || '';
+  
+    private data: string;
+    
+  
+    public shouldComponentUpdate(nextProps: ColumnProps) {
+      return this.data !== nextProps.node.version;
+    }
+  
+    render() {
+      const { version } = this.props.node;
+  
+      this.data = version;
+  
+      return (
+        <td className="Column" >
+         {version}
+        </td>
+      );
+    }
+  }

--- a/frontend/src/components/List/Column/index.ts
+++ b/frontend/src/components/List/Column/index.ts
@@ -33,3 +33,13 @@ export * from './BlockTimeColumn';
 export * from './BlockPropagationColumn';
 export * from './LastBlockColumn';
 export * from './UptimeColumn';
+export * from './CpuArchitectureColumn'; //starts here
+export * from './CpuCoresColumn';
+export * from './LinuxDistroColumn';
+export * from './IsVirtualMachineColumn';
+export * from './MemoryColumn';
+export * from './CpuColumn';
+export * from './OperatingSystemColumn';
+export * from './VersionColumn';
+export * from './LinuxKernelColumn';
+

--- a/frontend/src/components/List/Column/index.ts
+++ b/frontend/src/components/List/Column/index.ts
@@ -33,7 +33,7 @@ export * from './BlockTimeColumn';
 export * from './BlockPropagationColumn';
 export * from './LastBlockColumn';
 export * from './UptimeColumn';
-export * from './CpuArchitectureColumn'; //starts here
+export * from './CpuArchitectureColumn'; //extra columns added 
 export * from './CpuCoresColumn';
 export * from './LinuxDistroColumn';
 export * from './IsVirtualMachineColumn';

--- a/frontend/src/components/List/Row.css
+++ b/frontend/src/components/List/Row.css
@@ -44,5 +44,5 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 }
 
 .Row:hover {
-  background-color: #1e1e1e;
+  background-color: #1e1e1e;  /*remember to change to #1e1e1e*/
 }

--- a/frontend/src/components/List/Row.tsx
+++ b/frontend/src/components/List/Row.tsx
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+// Each Row in the List Page 
 import * as React from 'react';
 import { Types } from '../../common';
 import { Node } from '../../state';
@@ -38,6 +39,15 @@ import {
   BlockPropagationColumn,
   LastBlockColumn,
   UptimeColumn,
+  CpuArchitectureColumn,
+  CpuColumn,
+  CpuCoresColumn,
+  MemoryColumn,
+  OperatingSystemColumn,
+  VersionColumn,
+  IsVirtualMachineColumn,
+  LinuxDistroColumn,
+  LinuxKernelColumn
 } from './';
 
 import './Row.css';
@@ -72,8 +82,16 @@ export class Row extends React.Component<RowProps, RowState> {
     BlockPropagationColumn,
     LastBlockColumn,
     UptimeColumn,
+    CpuArchitectureColumn,
+    CpuColumn,
+    CpuCoresColumn,
+    LinuxDistroColumn,
+    LinuxKernelColumn,
+    MemoryColumn,
+    OperatingSystemColumn,
+    VersionColumn,
+    IsVirtualMachineColumn
   ];
-
   private renderedChangeRef = 0;
 
   public shouldComponentUpdate(nextProps: RowProps): boolean {
@@ -85,6 +103,9 @@ export class Row extends React.Component<RowProps, RowState> {
 
   public render() {
     const { node, columns } = this.props;
+
+  console.log('node details:',node );
+
 
     this.renderedChangeRef = node.changeRef;
 

--- a/frontend/src/state.ts
+++ b/frontend/src/state.ts
@@ -58,11 +58,25 @@ export class Node {
   public readonly id: Types.NodeId;
   public readonly name: Types.NodeName;
   public readonly implementation: Types.NodeImplementation;
-  public readonly version: Types.NodeVersion;
+  public readonly version: Types.NodeVersion; //step 3
   public readonly validator: Maybe<Types.Address>;
   public readonly networkId: Maybe<Types.NetworkId>;
   public readonly startupTime: Maybe<Types.Timestamp>;
+  public readonly target_os: Types.OperatingSystem; //starts here //step 3
+  public readonly target_arch: Types.CpuArchitecture; 
+  public readonly target_env: Types.TargetEnv; 
+  public readonly sysInfo: Types.NodeSysInfo;
 
+
+  public readonly cpu: Types.Cpu;
+  public readonly memory: Types.Memory;
+  public readonly core_count: Types.CpuCores;
+  public readonly linux_kernel: Types.LinuxKernel;
+  public readonly linux_distro: Types.LinuxDistro;
+  public readonly is_virtual_machine: Types.VirtualMachine;
+ 
+  
+  
   public readonly sortableName: string;
   public readonly sortableVersion: number;
 
@@ -100,9 +114,10 @@ export class Node {
     nodeHardware: Types.NodeHardware,
     blockDetails: Types.BlockDetails,
     location: Maybe<Types.NodeLocation>,
-    startupTime: Maybe<Types.Timestamp>
+    startupTime: Maybe<Types.Timestamp>,
+     
   ) {
-    const [name, implementation, version, validator, networkId] = nodeDetails;
+    const [name, implementation, version, validator, networkId, target_os, target_arch, target_env, sysInfo] = nodeDetails; //step 4
 
     this.pinned = pinned;
 
@@ -113,6 +128,27 @@ export class Node {
     this.validator = validator;
     this.networkId = networkId;
     this.startupTime = startupTime;
+    this.target_os = target_os;
+    this.target_arch = target_arch;
+    this.target_env = target_env;
+    this.sysInfo = {
+      cpu: sysInfo?.cpu ?? '', // Default value or some global constant
+      memory: sysInfo?.memory ?? 0,
+      core_count: sysInfo?.core_count ?? 0,
+      linux_kernel: sysInfo?.linux_kernel ?? '',
+      linux_distro: sysInfo?.linux_distro ?? '',
+      is_virtual_machine: sysInfo?.is_virtual_machine ?? false,
+    };
+
+    this.cpu = sysInfo && sysInfo.cpu ? Number(sysInfo.cpu) : 0; 
+    this.memory = sysInfo && sysInfo.memory ? Number(sysInfo.memory) : 0;
+    this.core_count = sysInfo && sysInfo.core_count ? Number(sysInfo.core_count) : 0; 
+    this.linux_kernel = sysInfo && sysInfo.linux_kernel ? Number(sysInfo.linux_kernel) : 0; 
+    this.linux_distro = sysInfo && sysInfo.linux_distro ? sysInfo.linux_distro : ''; 
+    this.is_virtual_machine = sysInfo && sysInfo.is_virtual_machine ? Boolean(sysInfo.is_virtual_machine) : false; 
+
+    
+    
 
     const [major = 0, minor = 0, patch = 0] = (version || '0.0.0')
       .split('.')
@@ -255,6 +291,22 @@ export interface StateSettings {
   blockpropagation: boolean;
   blocklasttime: boolean;
   uptime: boolean;
+
+  version: boolean; //starts here
+  target_os: boolean;
+  target_arch: boolean;
+  cpu: boolean;
+  core_count: boolean;
+  memory: boolean;
+  is_virtual_machine: boolean;
+  linux_distro: boolean;
+  linux_kernel: boolean;
+  cpu_hashrate_score: boolean;
+  memory_memcpy_score: boolean;
+  disk_sequential_write_score: boolean;
+  disk_random_write_score: boolean;
+  cpu_vendor: boolean;
+  
 }
 
 export interface State {

--- a/frontend/src/state.ts
+++ b/frontend/src/state.ts
@@ -58,11 +58,11 @@ export class Node {
   public readonly id: Types.NodeId;
   public readonly name: Types.NodeName;
   public readonly implementation: Types.NodeImplementation;
-  public readonly version: Types.NodeVersion; //step 3
+  public readonly version: Types.NodeVersion; 
   public readonly validator: Maybe<Types.Address>;
   public readonly networkId: Maybe<Types.NetworkId>;
   public readonly startupTime: Maybe<Types.Timestamp>;
-  public readonly target_os: Types.OperatingSystem; //starts here //step 3
+  public readonly target_os: Types.OperatingSystem; 
   public readonly target_arch: Types.CpuArchitecture; 
   public readonly target_env: Types.TargetEnv; 
   public readonly sysInfo: Types.NodeSysInfo;


### PR DESCRIPTION
Hello, this PR is focused on providing a more detailed view of node metrics on the telemetry platform, by mapping the extra node info aggregated as a summary in `ChainStats` to specific nodes in the nodes' list table.

Some of the key changes implemented include:

## Backend

-  Modified `NodeDetails` struct to include the extra information (`target_os`, `target_arch`, `target_env`, `sysinfo`) in `common/src/node_types.rs`
- Updated the `AddedNode` payload to always expose the `sysinfo` details by default to get the additional stats (`cpu`, `memory`, `core_count`, `linux_kernel`, `linux_distro`, `is_virtual_machine`) found in `NodeSysInfo`

## Frontend

- Updated the `Node` constructor to handle the extra details within `NodeDetails`
-  Added new columns and components to display the newly available information

The objective is to provide telemetry users with deeper insights into the operational aspects of nodes. By exposing more detailed system information, users can better understand and track node operations.
