### PR TITLE
Partial fix for overflow-y scroll issue

### DIFF
--- a/frontend/src/components/Chain/Chain.css
+++ b/frontend/src/components/Chain/Chain.css
@@ -30,5 +30,4 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
   min-height: 100%;
   background: #2c2b2b;
   color: #fff;
-  box-shadow: rgba(0, 0, 0, 0.5) 0 3px 30px;
 }

--- a/frontend/src/components/Chain/Header.css
+++ b/frontend/src/components/Chain/Header.css
@@ -24,6 +24,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
   color: #000;
   min-width: 1350px;
   position: relative;
+  background: linear-gradient(0deg, rgba(0,0,0,0.2) 0%, rgb(255, 255, 255) 17%), white;
 }
 
 .Header-tabs {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -21,6 +21,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
   box-sizing: border-box;
 }
 
+html, body {
+  background-color: #2c2b2b;
+}
+
 body {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
When lots of table columns are visible, scrolling to the right looks very ugly and the table cells are hard/impossible to read (see #592).

With this tweak, we match the table backgorund colour when we scroll off, and remove a box shadow which would otherwise cut down along the table.

Before:

<img width="1683" alt="Screenshot 2025-01-15 at 14 53 47" src="https://github.com/user-attachments/assets/b63c8ca6-fab1-44a8-a4f5-7a3ff1a61225" />

After:

<img width="1683" alt="Screenshot 2025-01-15 at 14 53 33" src="https://github.com/user-attachments/assets/8302621c-34d4-4f78-90c0-37d68c5896d0" />

This is far from the perfect fix (ideally the header would fill the space etc) but improves the situation at least.

An alternative is to just set `overflow-y: auto;` on the relevant component, but the downside to this is that, when there are too many rows to fit on one page, you can no longer see the scroll bar that you need to use to scroll the table.