### PR TITLE
Backend: add parallel cpu benchmarks processing

### DIFF
--- a/backend/common/src/node_message.rs
+++ b/backend/common/src/node_message.rs
@@ -98,6 +98,8 @@ pub struct NodeHwBench {
     pub memory_memcpy_score: u64,
     pub disk_sequential_write_score: Option<u64>,
     pub disk_random_write_score: Option<u64>,
+    pub parallel_cpu_hashrate_score: Option<u64>,
+    pub parallel_cpu_cores: Option<usize>,
 }
 
 impl Payload {

--- a/backend/common/src/node_types.rs
+++ b/backend/common/src/node_types.rs
@@ -73,6 +73,10 @@ pub struct NodeHwBench {
     pub disk_sequential_write_score: Option<u64>,
     /// Random disk write speed in MB/s.
     pub disk_random_write_score: Option<u64>,
+    /// The parallel CPU speed, as measured in how many MB/s it can hash using the BLAKE2b-256 hash.
+    pub parallel_cpu_hashrate_score: Option<u64>,
+    /// The number of cores used for the parallel CPU benchmark.
+    pub parallel_cpu_cores: Option<usize>,
 }
 
 /// A couple of node statistics.

--- a/backend/telemetry_core/src/feed_message.rs
+++ b/backend/telemetry_core/src/feed_message.rs
@@ -246,6 +246,7 @@ pub struct ChainStats {
     pub linux_distro: Ranking<String>,
     pub is_virtual_machine: Ranking<bool>,
     pub cpu_hashrate_score: Ranking<(u32, Option<u32>)>,
+    pub parallel_cpu_hashrate_score: Ranking<(u32, Option<u32>)>,
     pub memory_memcpy_score: Ranking<(u32, Option<u32>)>,
     pub disk_sequential_write_score: Ranking<(u32, Option<u32>)>,
     pub disk_random_write_score: Ranking<(u32, Option<u32>)>,

--- a/backend/telemetry_core/src/state/chain.rs
+++ b/backend/telemetry_core/src/state/chain.rs
@@ -213,6 +213,8 @@ impl Chain {
                         memory_memcpy_score: hwbench.memory_memcpy_score,
                         disk_sequential_write_score: hwbench.disk_sequential_write_score,
                         disk_random_write_score: hwbench.disk_random_write_score,
+                        parallel_cpu_hashrate_score: hwbench.parallel_cpu_hashrate_score,
+                        parallel_cpu_cores: hwbench.parallel_cpu_cores,
                     };
                     let old_hwbench = node.update_hwbench(new_hwbench);
                     // The `hwbench` for this node has changed, send an updated "add node".

--- a/backend/telemetry_core/src/state/chain_stats.rs
+++ b/backend/telemetry_core/src/state/chain_stats.rs
@@ -149,6 +149,7 @@ pub struct ChainStatsCollator {
     disk_sequential_write_score: Counter<(u32, Option<u32>)>,
     disk_random_write_score: Counter<(u32, Option<u32>)>,
     cpu_vendor: Counter<String>,
+    parallel_cpu_hashrate_score: Counter<(u32, Option<u32>)>,
 }
 
 impl ChainStatsCollator {
@@ -241,6 +242,14 @@ impl ChainStatsCollator {
                 .as_ref(),
             op,
         );
+
+        self.parallel_cpu_hashrate_score.modify(
+            hwbench
+                .and_then(|hwbench| hwbench.parallel_cpu_hashrate_score)
+                .map(|score| bucket_score(score, REFERENCE_CPU_SCORE))
+                .as_ref(),
+            op,
+        );
     }
 
     pub fn generate(&self) -> ChainStats {
@@ -261,6 +270,7 @@ impl ChainStatsCollator {
                 .generate_ranking_ordered(),
             disk_random_write_score: self.disk_random_write_score.generate_ranking_ordered(),
             cpu_vendor: self.cpu_vendor.generate_ranking_top(10),
+            parallel_cpu_hashrate_score: self.parallel_cpu_hashrate_score.generate_ranking_top(10),
         }
     }
 }

--- a/backend/telemetry_shard/src/json_message/node_message.rs
+++ b/backend/telemetry_shard/src/json_message/node_message.rs
@@ -211,6 +211,8 @@ pub struct NodeHwBench {
     pub memory_memcpy_score: u64,
     pub disk_sequential_write_score: Option<u64>,
     pub disk_random_write_score: Option<u64>,
+    pub parallel_cpu_hashrate_score: Option<u64>,
+    pub parallel_cpu_cores: Option<usize>,
 }
 
 impl From<NodeHwBench> for node_types::NodeHwBench {
@@ -220,6 +222,8 @@ impl From<NodeHwBench> for node_types::NodeHwBench {
             memory_memcpy_score: hwbench.memory_memcpy_score,
             disk_sequential_write_score: hwbench.disk_sequential_write_score,
             disk_random_write_score: hwbench.disk_random_write_score,
+            parallel_cpu_hashrate_score: hwbench.parallel_cpu_hashrate_score,
+            parallel_cpu_cores: hwbench.parallel_cpu_cores,
         }
     }
 }
@@ -231,6 +235,8 @@ impl From<NodeHwBench> for internal::NodeHwBench {
             memory_memcpy_score: msg.memory_memcpy_score,
             disk_sequential_write_score: msg.disk_sequential_write_score,
             disk_random_write_score: msg.disk_random_write_score,
+            parallel_cpu_hashrate_score: msg.parallel_cpu_hashrate_score,
+            parallel_cpu_cores: msg.parallel_cpu_cores,
         }
     }
 }


### PR DESCRIPTION
Updates telemetry backend to process and expose the `parallel_cpu_hashrate_score` and `parallel_cpu_cores` values sent by client as part of the [HwBench](https://github.com/paritytech/polkadot-sdk/blob/master/substrate/client/sysinfo/src/lib.rs#L56-L58) struct.

### Motivation

We need parallel CPU metrics to spot validators with poor real-world performance. HT/SMT can mask issues in single-threaded tests.